### PR TITLE
Add support for IMCOM coadd

### DIFF
--- a/notebooks/achromatic_IMCOM_galaxy_catalog.ipynb
+++ b/notebooks/achromatic_IMCOM_galaxy_catalog.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1608165e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "from roman_shear_sims.sim import make_sim\n",
+    "from roman_shear_sims.catalog import GalaxyCatalog\n",
+    "from roman_shear_sims.psf_makers import PSFMaker\n",
+    "from roman_shear_sims.constant import IMCOM_BLOCK_SIZE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e9de8143",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c4eba480",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seed = 4242\n",
+    "rng = np.random.RandomState(seed)\n",
+    "\n",
+    "simu_type = \"imcom\"\n",
+    "simu_size = IMCOM_BLOCK_SIZE\n",
+    "bands = [\"Y106\", \"J129\", \"H158\"]\n",
+    "psf_type = simu_type\n",
+    "layout_kind = \"grid\"\n",
+    "chromatic=False\n",
+    "spacing = 12.\n",
+    "buff = 200\n",
+    "noise_sig = 1e-5\n",
+    "n_gal = None\n",
+    "gal_mag = 25\n",
+    "gal_hlr = 0.2\n",
+    "flux_range = [100, 1_00]\n",
+    "\n",
+    "g1_in = 0.02\n",
+    "g2_in = 0.0\n",
+    "\n",
+    "n_epochs = 1\n",
+    "\n",
+    "exp_time=107"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8ac32a4",
+   "metadata": {},
+   "source": [
+    "### Set Galaxy Catalog"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "7e82c0ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "galaxy_catalog = GalaxyCatalog(\n",
+    "    simu_size,\n",
+    "    seed,\n",
+    "    simu_type=simu_type,\n",
+    "    flux_range=flux_range,\n",
+    "    layout_kind=layout_kind,\n",
+    "    exp_time=exp_time,\n",
+    "    spacing=spacing,\n",
+    "    buffer=buff,\n",
+    "    n_gal=n_gal,\n",
+    "    chromatic=chromatic,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc06ca1d",
+   "metadata": {},
+   "source": [
+    "### Set the PSF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "4cda07f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "psf_maker = PSFMaker(\n",
+    "    psf_type=psf_type,\n",
+    "    chromatic=chromatic,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3cc7a46",
+   "metadata": {},
+   "source": [
+    "### Run the simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "84b55c2f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b64818a7c816443980d4968b83af613c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Band loop:   0%|          | 0/3 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6bc254067e28480091f0db42fefe7a16",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Epoch loop:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3ba79197c3264cd299ee17073df0ba65",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Obj loop:   0%|          | 0/64 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7345c8c8518d4569805d0a91979dc683",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Epoch loop:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0ea67915395f47908b7e32f29fcfc24b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Obj loop:   0%|          | 0/64 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "16ce1421ec44436bb2962e1b76d9a9fb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Epoch loop:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2cba8aae11ad4562b08c49194a3ecb71",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Obj loop:   0%|          | 0/64 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "simu_dict = make_sim(\n",
+    "    rng,\n",
+    "    galaxy_catalog,\n",
+    "    psf_maker,\n",
+    "    simu_type=simu_type,\n",
+    "    n_epochs=n_epochs,\n",
+    "    exp_time=exp_time,\n",
+    "    cell_size_pix=simu_size,\n",
+    "    bands=bands,\n",
+    "    g1=g1_in,\n",
+    "    g2=g2_in,\n",
+    "    chromatic=chromatic,\n",
+    "    simple_noise=True,\n",
+    "    noise_sigma=noise_sig,\n",
+    "    draw_method=\"fft\",\n",
+    "    verbose=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a219dc53",
+   "metadata": {},
+   "source": [
+    "### Show output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c30eb919",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.colorbar.Colorbar at 0x330a15f40>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAApcAAAJ8CAYAAACr74rQAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAe7RJREFUeJzt3Xl4VOX9///X7JOEZEjIjjEEtIgFsYaKUKlaMUiLeyuVltp+rS2tSxH9VS22tbaVVlu1rVu1LtW6te6tlBqr4gJufMC6gKICCZCQhWQmy+wzvz+8znECqMCMSc7x+biuuSAnd2bOPefMOe/zft/nHkc6nU4LAAAAyAHnUK8AAAAA7IPgEgAAADlDcAkAAICcIbgEAABAzhBcAgAAIGcILgEAAJAzBJcAAADIGYJLAAAA5Ix7qFcAAABguIhEIorFYkPy2l6vV36/f0heO5cILgEAAPR+YFlXV6fW1tYhef3Kykpt2LDB8gEmwSUAAICkWCym1tZWNTc3q6ioaFBfOxQKqaamRrFYjOASAADATgoLC1VYWDior5lOpwf19T5J3NADAACAnCG4BAAAQM5QFgcAAMiQTqcHvUxNWRwAAADYBTKXAAAAGchcZofMJQAAAHKG4BIAAAA5Q1kcAAAgA2Xx7JC5BAAAQM6QuQQAAMhA5jI7ZC4BAACQM2QuAQAAMpC5zA6ZSwAAAOQMwSUAAAByhrI4AABABsri2SFzCQAAgJwhcwkAAJCBzGV2yFwCAAAgZwguAQAAkDOUxQEAADJQFs8OmUsAAADkDJlLAACADGQus0PmEgAAADlD5hIAACADmcvskLkEAABAzhBcAgAAIGcoiwMAAGSgLJ4dMpcAAADIGTKXAAAAGchcZofMJQAAAHKG4BIAAAA5Q1kcAAAgA2Xx7JC5BAAAQM6QuQQAAMhA5jI7ZC4BAACQMwSXAAAAyBnK4gAAABkoi2eHzCUAAAByhswlAABABjKX2SFzCQAAYFHXX3+96urq5Pf7VV9fr2efffZD27a0tGjevHkaP368nE6nFi5cuMt23d3dOuuss1RVVSW/368JEyZo6dKlu71OBJcAAAAZjMzlYD/21H333aeFCxdq8eLFWr16tWbMmKHZs2erqalpl+2j0ajKysq0ePFiTZ48eZdtYrGYjjnmGG3cuFH333+/3nrrLd18880aPXr0bq+XI22nPCwAAMBeCoVCCgQC2rBhg4qKigb9tevq6hQMBnf7tadOnapDDjlEN9xwg7lswoQJOvHEE7VkyZKP/NsjjzxSBx98sK655poBy2+88UZdeeWVWrdunTwezx73QyJzCQAAMGyEQqEBj2g0ust2sVhMq1atUkNDw4DlDQ0NWrFixV6//qOPPqpp06bprLPOUkVFhSZOnKjLL79cyWRyt5+D4BIAAGAHQ1USr6mpUSAQMB8floHs6OhQMplURUXFgOUVFRVqbW3d636/9957uv/++5VMJrV06VJdcskl+v3vf69f//rXu/0c3C0OAAAwTDQ3Nw8oi/t8vo9s73A4BvycTqd3WrYnUqmUysvLddNNN8nlcqm+vl5bt27VlVdeqZ/97Ge79RwElwAAABmGciqioqKi3RpzWVpaKpfLtVOWsq2tbads5p6oqqqSx+ORy+Uyl02YMEGtra2KxWLyer0f+xyUxQEAACzG6/Wqvr5ejY2NA5Y3NjZq+vTpe/28X/jCF/TOO+8olUqZy95++21VVVXtVmApEVwCAABY0qJFi/SXv/xFt956q9auXavzzjtPTU1NWrBggSTp4osv1re+9a0Bf7NmzRqtWbNGvb29am9v15o1a/Tmm2+av//BD36gzs5O/ehHP9Lbb7+txx57TJdffrnOOuus3V4vyuIAAAAZrPINPXPnzlVnZ6cuu+wytbS0aOLEiVq6dKlqa2slvT9p+o5zXn7uc58z/79q1Srdfffdqq2t1caNGyW9f0PR448/rvPOO08HHXSQRo8erR/96Ee68MILd3u9mOcSAABAH8xz+e6776qwsHBQX7unp0fjxo3bo3kuhysylwAAABmskrkcrhhzCQAAgJwhcwkAAJCBzGV2yFwCAAAgZwguAQAAkDOUxQEAADJQFs+ObYPLVCqlrVu3qrCwMKvv2AQAAIMnnU6rp6dH1dXVcjopsFqRbYPLrVu3qqamZqhXAwAA7IXm5mbts88+Q/LaZC6zY9tLgsGe/BQAAOQO53Hrsm1wSSkcAADr4jxuXbYtiwMAAOwNyuLZsW3mEgAAAIOPzCUAAEAGMpfZIXMJAACAnCFzCQAAkIHMZXbIXAIAACBnCC4BAACQM5TFAQAAMlAWzw6ZSwAAAOQMmUsAAIAMZC6zQ+YSAAAAOUNwCQAAgJyhLA4AAJCBsnh2yFwCAAAgZ8hcAgAAZCBzmR0ylwAAAMgZMpcAAAAZyFxmh8wlAAAAcobgEgAAADlDWRwAACADZfHskLkEAABAzpC5BAAAyEDmMjtkLgEAAJAzBJcAAADIGcriAAAAGSiLZ4fMJQAAAHKGzCUAAMAO7JRJHGx7lLlcsmSJPv/5z6uwsFDl5eU68cQT9dZbbw1o8+1vf1sOh2PA47DDDhvQJhqN6pxzzlFpaakKCgp0/PHHa/PmzQPadHV1af78+QoEAgoEApo/f766u7v3rpcAAAAYFHsUXC5fvlxnnXWWXnjhBTU2NiqRSKihoUF9fX0D2h177LFqaWkxH0uXLh3w+4ULF+qhhx7Svffeq+eee069vb2aM2eOksmk2WbevHlas2aNli1bpmXLlmnNmjWaP39+Fl0FAAD4eMaYy8F+2MUelcWXLVs24OfbbrtN5eXlWrVqlb74xS+ay30+nyorK3f5HMFgULfccovuvPNOzZw5U5L0t7/9TTU1NXriiSc0a9YsrV27VsuWLdMLL7ygqVOnSpJuvvlmTZs2TW+99ZbGjx+/R50EAADA4Mjqhp5gMChJKikpGbD86aefVnl5uT7zmc/ozDPPVFtbm/m7VatWKR6Pq6GhwVxWXV2tiRMnasWKFZKklStXKhAImIGlJB122GEKBAJmGwAAAAw/e31DTzqd1qJFi3T44Ydr4sSJ5vLZs2fra1/7mmpra7Vhwwb99Kc/1Ze+9CWtWrVKPp9Pra2t8nq9Ki4uHvB8FRUVam1tlSS1traqvLx8p9csLy832+woGo0qGo2aP4dCob3tGgAA+BRjKqLs7HVwefbZZ+t///ufnnvuuQHL586da/5/4sSJmjJlimpra/XYY4/p5JNP/tDnS6fTcjgc5s+Z//+wNpmWLFmiX/ziF3vaDQAAAOTQXpXFzznnHD366KN66qmntM8++3xk26qqKtXW1mr9+vWSpMrKSsViMXV1dQ1o19bWpoqKCrPNtm3bdnqu9vZ2s82OLr74YgWDQfPR3Ny8N10DAACfctzQk509Ci7T6bTOPvtsPfjgg3ryySdVV1f3sX/T2dmp5uZmVVVVSZLq6+vl8XjU2NhotmlpadHrr7+u6dOnS5KmTZumYDCol156yWzz4osvKhgMmm125PP5VFRUNOABAACAwbVHZfGzzjpLd999tx555BEVFhaa4x8DgYDy8vLU29urSy+9VKeccoqqqqq0ceNG/eQnP1FpaalOOukks+0ZZ5yh888/X6NGjVJJSYkuuOACTZo0ybx7fMKECTr22GN15pln6s9//rMk6Xvf+57mzJnDneIAAADD2B4FlzfccIMk6cgjjxyw/LbbbtO3v/1tuVwuvfbaa7rjjjvU3d2tqqoqHXXUUbrvvvtUWFhotr/66qvldrt16qmnKhwO6+ijj9btt98ul8tltrnrrrt07rnnmneVH3/88br22mv3tp8AAAC7hRt6suNI26k3GUKhkAKBwFCvBgAA2AvBYHDQh7gZscNLL72kESNGDOpr9/b26tBDDx2Sfuca3y0OAACQgcxldrKaRB0AAADIROYSQFaMuWftdNW9I7v30e79A/YUmcvsEFwOYw6Hw1Y724exaz8dDof5MPpnp7nMHA6HnE7ngD6mUilb9tHpfL/IY6c+Zm6/Hftn9BHW43A45HK5lE6nlUwmh3p18ClFcDmMZJ7IjIO+NPCAb6eDvtPplMvlksvlUiqVUiKRUCqVGurVygnjAG88JCmZTJp9tPo2NPrn8XjkdrvldDqVSqUUj8eVSCSUTCZt1UefzyeXy6VEIqFYLKZ4PG7pPhp9c7vd8ng88nq9crlcSiaTisfjZh/tsK9msnuG1ul0Ki8vTyNGjFAkElFvby8BJoYEweUwYASVxoHe7/crLy9Pfr9fTqdT8Xhc/f39CofDtjixSe8fBH0+n0aNGqVAIKBQKKTOzk5FIhHLB5jG9vR4PBoxYoQCgYAcDoeCwaB6e3sVjUYtf9I2+pefn6/i4mIVFhYqGo1q+/bt6unpUTQatfw+6nA45Ha7VVhYqIqKChUXF6u3t1etra3q7u42+2hFRnDp8/kUCAQ0atQojRw5UqlUStu3b1dHR4d6enoUiUQsvx2l9/vr8XhUUFAgSerr61M8Hrd8v3bk8/k0YcIEHXTQQVq9erXWrl1r2X10qFEWzw7B5TBgnMT8fr8KCwtVWVmp/fbbT5/97GdVWlqq1tZWvfbaa3r33XfV1tY24ORt1UDM7XarvLxc8+bN0xe/+EU1NjbqH//4h1pbWy3bp0wul0t5eXnab7/9NG/ePJWUlOiee+7RSy+9ZGaHrHogMcrgbrdbI0eO1Oc//3nNmTNH3d3duv/++/Xmm2+a+6ZV+yh9EECXlpaqoaFBc+bM0aZNm3THHXfotddes3wW2uFwyOv1qri4WAcddJCOOuooVVRU6P/+7//03//+V+vXr1dXV5cikYgSicRQr25WnE6nysrKdMYZZ2ifffbRrbfeqtWrVysajQ71quWM0cfzzz9fRx99tH7729/q3XffVTQatew+CusiuBwGMjOXI0aM0D777KMvfelL+upXv6qioiL19/dr6dKleuihh8zSqpFNsOLYLyMw2W+//bRgwQLV1NSosrJSTz/9tNrb25VIJCzXp0xG8OXxeHTQQQfpO9/5jvLy8pRIJLRu3Tr19vZa/mRt9DEvL09HHXWU5s6dq3g8ru3bt2vz5s3q6+uzxTAHp9OpwsJCzZw5U0cccYTC4bDWrVun9957z9yOVt1XjWOH0+lUeXm5Zs6cqerqatXX1ysWi5mZS2M7WnlbOhwO7bPPPvr+97+vqqoqjRgxQuecc45isZhlt9+OXC6Xxo0bp2OOOUYlJSXaf//9zbG02HNkLrPDnjcMGGMqE4mEIpGIuru7tXHjRr399tvq7OxUe3u7gsGgWd4wTuxWl06nzXFdnZ2dtrnCNg5KiURCLS0tampqUjAYVEtLi6VP0Aajf6lUSpFIRM3NzQoGg+rv71csFpPL5TL3Tyvvp0Yf+/r69N5776mvr089PT0Kh8NDvWpZM272iEajCgaDevfdd7V69WqFQiHF43Hl5+crLy9PHo9nwPhvq0qn02pra9O6desUiUQUj8dtG3jF43GFw2G98cYbtgqeYS1kLoeBzMCyq6tLiURC3d3dWrNmjUaNGqV4PK62tjZt27ZN27dvVzgctnRJzgi83n33Xf3+97/XAQccoMbGRrW2ttpifJdx4o5EIlqzZo0WLVqkkpISrV271rxIsHofjZt3uru7tXTpUrW3t8vr9erVV19Vb2+vGURbuZ/GxU97e7vuu+8+bdq0SbFYTC+//LL6+/stfaFgBM7GONnXXntN119/vZ5++mk5nU699957Ay5orS6ZTGrr1q1auHChDjroIL355pvq7e0d6tXKqXQ6rc2bN+vOO++UJC1btkyxWGyI1wqfVnz94zBi3CVu3Njj8XjMLFAikVAikRhwN66VT25Op1N+v19FRUXyeDzq7e21fJkxk3HDhNfrNe80jsfjikajtrgL1xjK4fV6lZeXp/z8fLndbkWjUfX19Q3op5UZN70UFBRoxIgRcjqd5r5qh5uWjOONz+dTfn6+RowYIY/Ho3g8rr6+PvX39w8ojVtZ5h3yxsWRlbfdjowhHFVVVYpGo2ptbVUkErF0H4fy6x+ff/75Ifn6xy984Qt8/SNyyxjXlEwmFYvFBpS/M8dXWvlgYTBKqkY/7TbNUmbZMR6PD5gH0g79NPoSi8WUTCYVDofNPiaTScsHXQYju5dIJNTX1yeHw7HTuGcrM4Is45jT09NjlouN7WiHfkofVEysPt75wxhDOJqamsztaYftBmuy56ATizNO3MZJLDNTaaeDhTEcwA5TK+2KEWjtmHG2Sz+N/hkZ2Wg0qlgsZukhGzvK7GMkEjEviOy4HWOxmCKRiMLhsMLhsHlhZKe+2l0ikTC3HdssOzsmdAbrsTeuv/561dXVye/3q76+Xs8+++yHtm1padG8efM0fvx4OZ1OLVy48COf+95775XD4dCJJ564R+tEcAl8wuyUcd6VzIshO14ESQP7aMf+SZ+O7fhpwDb7dLnvvvu0cOFCLV68WKtXr9aMGTM0e/ZsNTU17bJ9NBpVWVmZFi9erMmTJ3/kc2/atEkXXHCBZsyYscfrRXAJAABgQVdddZXOOOMMffe739WECRN0zTXXqKamRjfccMMu248ZM0Z/+MMf9K1vfesj70tJJpP6xje+oV/84hcaO3bsHq8XwSUAAEAGK5TFY7GYVq1apYaGhgHLGxoatGLFiqz6f9lll5lfPLA3uKEHAABgmAiFQgN+9vl88vl8O7Xr6OhQMplURUXFgOUVFRVqbW3d69d//vnndcstt2jNmjV7/RxkLgEAADIMZeaypqZGgUDAfCxZsuQj13XHLzlIp9N7/cUHPT09+uY3v6mbb75ZpaWle/UcEplLAACAYaO5uXnAPJe7ylpKUmlpqVwu105Zyra2tp2ymbvr3Xff1caNG3XccceZy4w5bt1ut9566y2NGzfuY5+H4BIAACDDUMzwYbxeUVHRbk2i7vV6VV9fr8bGRp100knm8sbGRp1wwgl7tQ4HHHCAXnvttQHLLrnkEvX09OgPf/iDampqdut5CC4BAAAsaNGiRZo/f76mTJmiadOm6aabblJTU5MWLFggSbr44ou1ZcsW3XHHHebfGGMpe3t71d7erjVr1sjr9erAAw+U3+/XxIkTB7zGyJEjJWmn5R+F4BIAAMCC5s6dq87OTl122WVqaWnRxIkTtXTpUtXW1kp6f9L0Hee8/NznPmf+f9WqVbr77rtVW1urjRs35my9+G5xAAAw7Azld4s//fTTQ/Ld4kceeaQtvlucu8UBAACQM5TFAQAAMgzlDT12QOYSAAAAOUNwCQAAgJyhLA4AAJCBsnh2yFwCAAAgZ8hcAgAAZCBzmR0ylwAAAMgZMpcAAAA7sFMmcbCRuQQAAEDOEFwCAAAgZyiLAwAAZOCGnuyQuQQAAEDOkLkEAADIQOYyO2QuAQAAkDMElwAAAMgZyuIAAAAZKItnh8wlAAAAcobMJQAAQAYyl9khcwkAAICcIXMJAACQgcxldshcAgAAIGcILgEAAJAzlMUBAAAyUBbPDplLAAAA5AyZSwAAgAxkLrND5hIAAAA5Q3AJAACAnKEsDgAAkIGyeHbIXAIAACBnyFwCAABkIHOZHTKXAAAAyBkylwAAABnIXGaHzCUAAAByhuASAAAAOUNZHAA+5RwOx4Cf7VSeA/YGZfHsEFwOcw6Hw1Y7XCZOaMDQczgccjqd5v+Nk+pQnFyRHYfDYR5X2X4YSgSXw5jb7ZbH41EsFlMymRzq1ckZp9NpHgSNk1o6nVYqlTL/BYaTzAshO52wnU7ngIcRXCaTSaVSKfMzaXWZxxwj6LLTcSbzeGocU43tZ6d+DiYyl9khuBymHA6H8vLyVFpaqs7OTvX09Nhix3M6nXK5XHK73eZDkpLJpOLxuBKJhCSuuq3ACLgys+t23GbGPut0OgcEXlbvqxGQuFwueb1e+Xw+OZ1OJZNJRaNR8/No9b46nU653W55vV65XC6lUinF43HF43HL983gcDjMPno8HklSLBZTLBaTJAJMDDqCy2HK5XKpurpas2fP1vPPP69XX33VPFBYlXGS9ng8ysvLU1FRkYqLi+XxeBQKhdTV1aXe3l7FYjElEglbHPQ9Ho/y8/PldrsViUQUiUQsnYU2ghG32y2fzyev1yu32610Oq1IJKJwOGyetO3A6XTK4/EoEAiopKRE/f396uzstPx2lD4oh3s8HhUWFqq8vFwjR45UMBjUtm3bFAqFzODLqp9FY3/1+/0qKytTZWWlksmktmzZou3bt9tqO3q9Xo0cOVIVFRVyOBzatm2burq6FI1GLb0NYU0El8OUx+PRUUcdpZ/97Gd66KGH9OMf/1jbt2+3/AHCOAgGAgGNHz9exx13nPbbbz8988wzevzxx9XU1KSenh7Ln9QkKT8/XwcffLBOP/101dTU6Mknn9Tf//53bd261czQWpHT6VR+fr6qqqp0yCGH6KijjtLo0aO1YcMG3X///VqzZo1CoZDi8bilt5/0fl9HjBihr3zlK/rud7+r//3vf7r66qu1adMmS2e9MsuoXq9XZWVl+trXvqZZs2ZpxYoV+utf/6poNGpmLq089tvhcMjv92vChAk699xzVVpaqttvv10PPfSQ2tvbLV8izwygJ0yYoAULFigvL0833XSTVq5cqXg8buntN1Qoi2eH4HKYcrlcOuiggzRy5EjNmDFDI0eOVFdXl6V3vswyqs/n05gxY3TyyServLxco0eP1jvvvKPt27cPyH5Ztb9Op1OBQEBz587VGWecIafTqcmTJ+vNN99UR0eHZYPLdDqtRCKhcDisvr4+ud1uHX744dpvv/2UTqf1hS98Qb/5zW/07LPPqr29XdFo1PIn7ry8PM2ZM0fTpk3T+PHj9fDDD2vz5s22OGEbAWYgEFBDQ4MOOeQQFRcX6z//+Y+2bNky4AYRqzKChFGjRunQQw9VUVGRTjvtNK1YsULd3d2Kx+NDvYpZczgc8nq9mjx5sr7yla/I7XZr/fr1evXVV9XT02PZ4w2si+BymEokEnr55Zf19a9/XevWrVN/f7/lT2TGQT6ZTCocDmvLli1as2aNJk+erPXr1yscDiudTtvmhBYOh/XKK6/ojTfe0KhRo7R8+XI1NTVZ/kCfSqUUiUTU0tKif//73+ru7ta8efNUU1OjzZs3y+/3KxAIqLe31xxLa9V91yj3r1ixQvX19Xrrrbe0bds2y2fVDUbWLhQKaeXKlSotLdXLL7+s7u5us1xs5X4a2ykSiWjt2rVavny5Dj30UL333nuSZItjjfTBRV9TU5M2bdqkwsJCbdq0yTbDi4YCmcvsONJ26k2GUCikQCAw1Kux14wxl1/96le1fv16Pfnkk+rv7x/q1cpK5hiv/Px8lZSUqLa2VuXl5ers7NTmzZvV2dlpjrs0bpywKqOkWlVVpfz8fG3btk0dHR2WHzubybgZpKCgQPn5+ZKkeDxuji+Nx+NKJpOWPWgaZePS0lKNGTNGoVBITU1NZuBs1X5JH4yB9vl8Kioq0ujRo1VVVaWuri41NTWpu7tbkUjE8jf1GDf0FBYWat9999W+++6rrq4ubdy40RbjZ42befx+v8rLyzVx4kTl5+frzTffVHNzs/r6+iw7DjoYDKqoqGhQX9OIHR566CEVFBQM6mv39fXppJNOGpJ+5xrB5TDm9/tVWVmpaDSq9vZ2y2e8pIE3hBh3qHo8HqVSKcViMfMuVbvckSt9MBzADn35MDtmgOx097gRnBg3Llk9YDYYF3vGlGd+v9/8LEYiEcViMTMosWJgkinzjnGv1ytJ5vHGDtk9o39+v195eXlyOp2KRqPmECOr7q9DGVw++OCDQxJcnnzyybYILimLD2PRaFStra1mKdkOjL4Y/0ajUTMoyZyXzS5lR8keAdbHsdP22pExdU1mEGKHvholcaNfyWTS/Cwmk0lbXeAZ2zCZTCoSicjhcNjqOJM53CgWi5n9M7ajHfoIayG4HMbS6bSi0aj5f7vInCtwV9/SY6e+wh7sul9mfnlBZnBpx2/psdNF+o4yj6nGdrTb9oO1EFwOc3Y+MHDgA4beh2Vj+WxaD8fU3OGGnuwQXALAp5ydTmoAhh7BJQAAQAYyl9lxDvUKAAAAwD4ILgEAAJAzlMUBAAB2YKcy9WAjcwkAAICcIXMJAACQgRt6skPmEgAAADlD5hIAACADmcvskLkEAABAzuxRcLlkyRJ9/vOfV2FhocrLy3XiiSfqrbfeGtAmnU7r0ksvVXV1tfLy8nTkkUfqjTfeGNAmGo3qnHPOUWlpqQoKCnT88cdr8+bNA9p0dXVp/vz5CgQCCgQCmj9/vrq7u/eulwAAABgUexRcLl++XGeddZZeeOEFNTY2KpFIqKGhQX19fWabK664QldddZWuvfZavfzyy6qsrNQxxxyjnp4es83ChQv10EMP6d5779Vzzz2n3t5ezZkzR8lk0mwzb948rVmzRsuWLdOyZcu0Zs0azZ8/PwddBgAA+HBGWXywH3bhSGfRm/b2dpWXl2v58uX64he/qHQ6rerqai1cuFAXXnihpPezlBUVFfrtb3+r73//+woGgyorK9Odd96puXPnSpK2bt2qmpoaLV26VLNmzdLatWt14IEH6oUXXtDUqVMlSS+88IKmTZumdevWafz48R+7bqFQSIFAYG+7BgAAhlAwGFRRUdGgvqYRO9x3333Kz88f1Nfu7+/X3Llzh6TfuZbVmMtgMChJKikpkSRt2LBBra2tamhoMNv4fD4dccQRWrFihSRp1apVisfjA9pUV1dr4sSJZpuVK1cqEAiYgaUkHXbYYQoEAmYbAACAT4KVMpfXX3+96urq5Pf7VV9fr2efffZD27a0tGjevHkaP368nE6nFi5cuFObm2++WTNmzFBxcbGKi4s1c+ZMvfTSS3u0TnsdXKbTaS1atEiHH364Jk6cKElqbW2VJFVUVAxoW1FRYf6utbVVXq9XxcXFH9mmvLx8p9csLy832+woGo0qFAoNeAAAANjVfffdp4ULF2rx4sVavXq1ZsyYodmzZ6upqWmX7aPRqMrKyrR48WJNnjx5l22efvppnXbaaXrqqae0cuVK7bvvvmpoaNCWLVt2e732Org8++yz9b///U/33HPPTr9zOBwDfk6n0zst29GObXbV/qOeZ8mSJebNP4FAQDU1NbvTDQAAAEu66qqrdMYZZ+i73/2uJkyYoGuuuUY1NTW64YYbdtl+zJgx+sMf/qBvfetbHzp08K677tIPf/hDHXzwwTrggAN08803K5VK6b///e9ur9deBZfnnHOOHn30UT311FPaZ599zOWVlZWStFN2sa2tzcxmVlZWKhaLqaur6yPbbNu2bafXbW9v3ykrarj44osVDAbNR3Nz8950DQAAfMoNZVl8xypsNBrd5TrGYjGtWrVqwDBDSWpoaMjpEML+/n7F43FzCOTu2KPgMp1O6+yzz9aDDz6oJ598UnV1dQN+X1dXp8rKSjU2NprLYrGYli9frunTp0uS6uvr5fF4BrRpaWnR66+/braZNm2agsHggBr/iy++qGAwaLbZkc/nU1FR0YAHAACAldTU1AyoxC5ZsmSX7To6OpRMJj9yKGIuXHTRRRo9erRmzpy523+zR9/Qc9ZZZ+nuu+/WI488osLCQnPlA4GA8vLy5HA4tHDhQl1++eXaf//9tf/+++vyyy9Xfn6+5s2bZ7Y944wzdP7552vUqFEqKSnRBRdcoEmTJpkrPmHCBB177LE688wz9ec//1mS9L3vfU9z5szZrTvFAQAA9tZQfkNPc3PzgASZz+f7yL/bm6GIu+uKK67QPffco6efflp+v3+3/26Pgkujhn/kkUcOWH7bbbfp29/+tiTpxz/+scLhsH74wx+qq6tLU6dO1eOPP67CwkKz/dVXXy23261TTz1V4XBYRx99tG6//Xa5XC6zzV133aVzzz3XTPcef/zxuvbaa/dkdQEAACxld6uvpaWlcrlcHzkUMRu/+93vdPnll+uJJ57QQQcdtEd/u0fB5e5E8Q6HQ5deeqkuvfTSD23j9/v1pz/9SX/6058+tE1JSYn+9re/7cnqAQAAfCp4vV7V19ersbFRJ510krm8sbFRJ5xwQlbPfeWVV+pXv/qV/vOf/2jKlCl7/Pd7FFwCAADY3VCWxffEokWLNH/+fE2ZMkXTpk3TTTfdpKamJi1YsEDS+zc7b9myRXfccYf5N2vWrJEk9fb2qr29XWvWrJHX69WBBx4o6f1S+E9/+lPdfffdGjNmjJkZHTFihEaMGLFb60VwCQAAYEFz585VZ2enLrvsMrW0tGjixIlaunSpamtrJb1/w/SOc15+7nOfM/+/atUq3X333aqtrdXGjRslvT8peywW01e/+tUBf/fzn//8I6vSmbL6+sfhjK9/BADAuoby6x//9re/DcnXP37zm9/k6x8BAACATJTFAQAAMlhlzOVwReYSAAAAOUNwCQAAgJyhLA4AAJCBsnh2yFwCAAAgZ8hcAgAAZCBzmR0ylwAAAMgZgksAAADkDGVxAACADJTFs0PmEgAAADlD5hIAACADmcvskLkEAABAzpC5BAAAyEDmMjtkLgEAAJAzBJcAAADIGcriAAAAGSiLZ4fMJQAAAHKGzCUAAEAGMpfZIXMJAACAnCG4tBCHwzHUqwAAAPCRKIsPYw6Hw3wYjFS91dPnO/bNLv36ODtuSwx/H/YZBGBflMWzQ3A5TDmdTjmdTrlcLjmdTjkcDqVSKSWTSSWTSUvvhDv2TZKSyaRSqZT5sBOjv8Z2lDSgr1belnaXua86HA6l02lbbrsP2z/t0r8d7eri1g7HHYfDYW5Lyf7bEcMXweUw5HQ65Xa75fV65ff75fF4lEwmFY1GFYlElEwmh3oV95px8PN4PPL7/fL7/ZJk9i0ej0uSLQ70xnb0+XzmQ5Li8bii0aii0aji8bhtDv6ZJ2o7MILKHT+HkUhEsVhMiUTC8tvO4XCY+2heXp48Ho9SqZTC4bD5ebTDZ9FgbE+fzye32610Om1+HhOJhKWPrZnHVZ/Pp2QyqXA4rGg0aul+DRUyl9khuBxmjIAkLy9P5eXlGjt2rJxOp7Zs2aLW1lbFYjFLj710OBxyuVzy+/0qLy/XuHHjVFRUpHfffVdNTU0KhUJKpVJmlsiqXC6XfD6fRo4cqX333Vdjx46Vx+NRe3u7mpub1d7erkQioUQiYel+Op1O5efnq6ysTPn5+erp6VFXV5f6+/stfUIzslput1sjRoxQTU2Nxo4dq97eXr399ttqb29XOBy2fInc7XYrPz9fFRUVGj9+vGpra9Xd3a0333xTzc3NCoVCisVilu6j9P5+6vf7VVZWpnHjxqm6ulqRSETNzc3avHmzksmkEonEUK/mXnM4HPJ4PCouLtb48eM1evRobd68WevXr9f27dstfxEE6yG4HGaME1pxcbFOPvlknXnmmWptbdUVV1yh9vb2oV69rBknba/Xq7q6Ov34xz/WAQccoIcfflg33HCDIpGImRGyKrfbbZ7IPv/5z+t73/ueJk+erJaWFt11113q7OwcUF61Ko/Ho6qqKp122mn6+te/rqKiIj333HO67rrr9Oabb6qvr8/SJzTjszhy5Egdd9xxOvPMM9XZ2alf//rXeuaZZxSLxSwdQBsXskVFRZo8ebLOPvtsHXzwwero6NCNN96oxx57zPw8WrmfbrdbhYWFmjBhgk4//XTNmjVLBQUF+u9//6u//vWvam5uNoflWJXT6VReXp4mT56sn/3sZ9pvv/30wAMP6LrrrlMwGLT8xfpQ4T3be9wtPoxkloxLSko0c+ZMjR07Vp/5zGfk9/vNA6CVd3hj3R0OhwoKCrT//vurvLxchx56qIqLi+XxeAaM/bIao+wWCAQ0btw4HX/88friF7+okpISpVIpbd26VZ2dnerv77d0ydHpdKqgoECHHnqozjnnHE2ePFl1dXXab7/95HK5LNuvHRkB5tixY1VRUaH9999fY8aMkdfrtew+msnpdMrr9aqiokIHHHCACgsLtc8++2jfffeV3++39GdRkpl53n///fX//t//0+mnn659991XDodDa9eu1aZNm2yRnTWCy4MOOkj19fUqKyszq17AUCBzOcwYAWYqldKqVas0atQorVy5Um+99ZYikYjlg0vp/fGU0WhUGzZs0N///ndNmzZNTz31lILBoKX7l3lxkJeXp7y8PG3btk3PPfecOjo69K9//Usvvvii2traLD92Vnp/OzY3N+vvf/+7Jk2apE2bNumee+7Rm2++qUgkYtntmCmRSCgUCmnZsmUqLy9XT0+PXnvtNcsHI9L7F3rGuLz169fr3//+t6ZMmaLm5ma9+OKL6u7utvSwDSNwLioqUkVFhdxut9555x1t27ZNjzzyiJYtW6YtW7YoHA7b4mIonU6rpaVF69atk9/v19KlS7V9+3ZLb0NYlyNt070uFAopEAgM9WrskczxliUlJaqoqJDP51NbW5u2bdumvr4+S2e7pA/GXHo8HhUWFqq8vFzFxcXq7e1VW1ubgsGgObjeartm5vYrLCxUSUmJAoGA0um0uru71dHRoZ6eHnOAvdX6tyOn02neCOJ2uxWJRNTf32/psWuZMrfnyJEjVVZWJknq6OhQV1eXwuGwbYZwFBcXq7KyUiUlJert7VVLS4uZYbfiZ1GSObY7EAiorKxMxcXFSqVSam9v17Zt29Tb26t4PG7Jvu3I7XaroKBAo0eP1tixYxWPx7V+/Xpt27bN0heywWBQRUVFg/qaRuzw5z//WXl5eYP62uFwWN///veHpN+5RuZyGDFuDkgkEgoGg+rr61MymVQsFjPvTrX6gdAYaxiPx81Aq6WlRel02uynVbOXRt+i0ahSqZT6+vq0efNm88adeDxu+bFdmYy7isPh8FCvyiciM7NnfCYlDdiWVtxPM+3YP2NIQywWs3wfjTvBg8Ggent79d5775mfRTscSzOlUilFIhFt2bJFbW1tA2Y1sGpgCWsjuBxmjMDLOCDsOKeeHQ6ImX1JJBI7zTVn1eDLCEaMfhnstO0+TYz90fg3FouZyzN/Z2XGPmv0z7jxww77q3EsjcfjA/plR5nnDWNOZLvM3TlUmIooOwSXw0jmwSAzY2DHg2JmILnjt/RYmXGyhj18WKBl9f10R3b47O1K5jHU7qx8YQ77IbgcZj5Nwcmn6cAPa2MfBYDdR3AJAACQgbJ4dpgECwAAADlD5hIAACADmcvskLkEAABAzpC5BAAAyEDmMjtkLgEAAJAzBJcAAADIGcriAAAAGSiLZ4fMJQAAAHKGzCUAAEAGMpfZIXMJAACAnCG4BAAAQM5QFgcAAMhAWTw7ZC4BAACQM2QuAQAAMpC5zA6ZSwAAAOQMmUsAAIAMZC6zQ+YSAAAAOUNwCQAAgJyhLA4AAJCBsnh2yFwCAAAgZ8hcAgAAZCBzmR0ylwAAAMgZgksAAADkDGVxAACADJTFs0PmEgAAADlD5hIAACADmcvskLkEAABAzhBcAgAAZDAyl4P92BvXX3+96urq5Pf7VV9fr2efffZD27a0tGjevHkaP368nE6nFi5cuMt2DzzwgA488ED5fD4deOCBeuihh/ZonQguAQAALOi+++7TwoULtXjxYq1evVozZszQ7Nmz1dTUtMv20WhUZWVlWrx4sSZPnrzLNitXrtTcuXM1f/58vfrqq5o/f75OPfVUvfjii7u9Xo60nYr8GUKhkAKBwFCvBgAA2AvBYFBFRUWD+ppG7HDllVcqLy9vUF87HA7r//v//r896vfUqVN1yCGH6IYbbjCXTZgwQSeeeKKWLFnykX975JFH6uCDD9Y111wzYPncuXMVCoX073//21x27LHHqri4WPfcc89urReZSwAAgAxDWRYPhUIDHtFodJfrGIvFtGrVKjU0NAxY3tDQoBUrVux131euXLnTc86aNWuPnpPgEgAAYJioqalRIBAwHx+Wgezo6FAymVRFRcWA5RUVFWptbd3r129tbc36OZmKCAAAIMNQTkXU3Nw8oCzu8/k+8u8cDsdOz7Pjsj2V7XMSXAIAAAwTRUVFuzXmsrS0VC6Xa6eMYltb206Zxz1RWVmZ9XNSFgcAALAYr9er+vp6NTY2Dlje2Nio6dOn7/XzTps2bafnfPzxx/foOclcAgAA7MAKk+ksWrRI8+fP15QpUzRt2jTddNNNampq0oIFCyRJF198sbZs2aI77rjD/Js1a9ZIknp7e9Xe3q41a9bI6/XqwAMPlCT96Ec/0he/+EX99re/1QknnKBHHnlETzzxhJ577rndXi+CSwAAAAuaO3euOjs7ddlll6mlpUUTJ07U0qVLVVtbK+n9SdN3nPPyc5/7nPn/VatW6e6771Ztba02btwoSZo+fbruvfdeXXLJJfrpT3+qcePG6b777tPUqVN3e72Y5xIAAAw7QznP5W9+8xv5/f5Bfe1IJKKLLrpoSPqda4y5BAAAQM4QXAIAACBnGHMJAACQYSjnubQDMpcAAADIGTKXAPApZ3zzhp0yJ0A2yFxmh+ASGAScvDEcORwOOZ1OOZ3vF7HS6bRSqZRSqdQQrxkAKyO4BD5BxonbCC6NE7ddgkyHwzEgcLZbvxwOh9kvu/Qtk8PhkNvtlsfjkcvlUjKZVDweVzweJ8DEpxqZy+zs8ZjLZ555Rscdd5yqq6vlcDj08MMPD/j9t7/97QEHZofDocMOO2xAm2g0qnPOOUelpaUqKCjQ8ccfr82bNw9o09XVpfnz5ysQCCgQCGj+/Pnq7u7e4w5aWWZWIfMkbieZ+4nduFwueb1e5eXlqaCgQHl5efJ6vXK5XLbor9PplNvtltfrldfrNQMUq/fN4XCY287v9ys/P992287gdDrl9XpVVFSk0tJSlZaWasSIEfJ6vWY2E9ZgnC9cLpfcbrdcLteAC1tgMO1x5rKvr0+TJ0/Wd77zHZ1yyim7bHPsscfqtttuM3/2er0Dfr9w4UL985//1L333qtRo0bp/PPP15w5c7Rq1Sq5XC5J0rx587R582YtW7ZMkvS9731P8+fP1z//+c89XWXLMQ4SbrdbbrdbDodDqVRKyWRSiUTCFpkv4wTudrvldDpt1Tfpg8ByxIgRKi4uVl5ensLhsLq6utTb26t0Oq1kMjnUq7nXjH3U5/NpxIgR8ng8CofD6uvrUywWs/x2dDgc8ng8Kioq0ogRI+RwONTb26uenh6Fw2HF43FL90/6YBt6vV6NGjVKtbW1cjqd2rRpk7Zs2aJQKGSLfhqM/hrHUztlZo0khJGFdjqdSqVSSiQSSiQSSiaTts2+Y3ja4+By9uzZmj179ke28fl8qqys3OXvgsGgbrnlFt15552aOXOmJOlvf/ubampq9MQTT2jWrFlau3atli1bphdeeMH8uqGbb75Z06ZN01tvvaXx48fv6WpbhlGmys/PV2Vlpfbbbz8lEglt2bJF7e3t6unpUSwWUyKRGOpVzYrL5dKIESM0duxY7bvvvnr33Xe1adMm9fX1WTrokj4InPPz81VTU6OpU6equrpar7/+ul599VXFYjHF4/GhXs2sGX0cP368Jk+erM2bN+vll19WR0eHotGoZU9kxknY4XCooKBABx54oCZNmqRUKqUXX3xRr732mrq6umxTOvZ4PCovL9fMmTNVW1urJ598Uv/9738VjUaVTCYt/3mUJLfbrZKSEn32s59VRUWF3n77ba1fv159fX2W34ZGttLv92vkyJGqra3VqFGjtGXLFrW0tCgUCikajSqRSFj2MzkUKItn5xOpezz99NMqLy/XZz7zGZ155plqa2szf7dq1SrF43E1NDSYy6qrqzVx4kStWLFCkrRy5UoFAoEB32N52GGHKRAImG12FI1GFQqFBjysxggsCwoKNG7cOF144YX661//quuuu04NDQ0aNWqUPB6P5cvIRlZo3Lhx+v3vf6877rhDv/zlL7XPPvuY/bMyYzsWFhbqkEMO0aJFi3Teeefp+OOPV0lJiZmNtkM/8/LyNHPmTP3yl7/UlVdeqUMPPVR5eXmWL8elUinF43FFo1EVFhbq61//ui655BL99re/1fTp0zVy5EhzO1qVcSJLp9PKz8/XtGnTdNxxx+kb3/iGxo4da25Hq3M4HBoxYoSOPfZY3X777brtttt06623avr06crLyxvq1ctKZvY5EAjo0EMP1R/+8AfdcsstOuecc1RTU6O8vDzbDefA8JfzI8fs2bN111136cknn9Tvf/97vfzyy/rSl76kaDQqSWptbZXX61VxcfGAv6uoqFBra6vZpry8fKfnLi8vN9vsaMmSJeb4zEAgoJqamhz37JOXGZTst99+Ovzww1VSUqKSkhKlUilFIhFblI6NA2JhYaFqa2s1YsQI1dbWKi8vzxYHwMyS8ejRozV69Gjl5+eb+3zmSd3K0um0EomEvF6vmaU94IAD5PP5LB+UGMFlMBjUW2+9pXXr1snlcmnixIlqaGjQ6NGjzZO2lRn9NC7InU6namtrVVVVJb/fb5ugJJ1OmxUhn8+nmpoaVVdXW/5i1rhIdbvdysvLU11dnT7zmc+opKRENTU1crvdlMP3UuaNfIP5sIuc3y0+d+5c8/8TJ07UlClTVFtbq8cee0wnn3zyh/6dUYYy7OoDv2ObTBdffLEWLVpk/hwKhSwXYBp9SyQSampq0i233KLPfvazWrNmjf7zn/+ovb3dLFVZWTqdVjwe19tvv61f/vKXqq+v1zPPPKPm5mbblG7S6bRisZjWr1+v5cuXq7CwUP/+97/V2dlpm3JqMplUb2+vli5dqtraWgUCAb311lu22H7S+/3r6+vTO++8oz/+8Y/aunWrxo4dq/b2do0YMUJ5eXmKRCLmeDYrSqVSikajamlp0WOPPaaRI0cqFAopHA4PuJHQqv2T3v8s9vX16d///rcikYgmT56st99+W0899ZT6+/st3zfpg331pZde0nXXXaeysjItW7ZMzc3NCofDSiaTtjjmwDo+8amIqqqqVFtbq/Xr10uSKisrFYvF1NXVNSB72dbWpunTp5tttm3bttNztbe3q6KiYpev4/P55PP5PoEeDB5jAHYwGNTbb7+tTZs2yeVyKRwOq7+/37xRwuqMjFdHR4ceeOABPfroo4rFYua4IKszbtbp7e3V66+/rj/+8Y+SpObmZnV2dioWi1n6hCZ9MB9iJBLR66+/rl/+8pcqLCxUZ2enwuGw5fsnfbCfhkIhrV69Wk1NTSorK5Pb7VZ3d7fS6bQZgFm1v6lUSrFYTJ2dnXr22We1fft2+Xw+NTc322JcsCGRSKi1tVX333+/Hn74YTNja4cL9WQyqVgspmAwqDfffFMbNmyQw+FQf3+/wuGwYrGYpS+AYE2feHDZ2dmp5uZmVVVVSZLq6+vl8XjU2NioU089VZLU0tKi119/XVdccYUkadq0aQoGg3rppZd06KGHSpJefPFFBYNBMwC1I+NklkwmFY1GzayBUQa3Q2BpMA7uiUTCdnMJGtuxv79fW7duVWdnpxmIhcNhc2iD1RnbsKenR9FoVG632wxWrD50w2Bsy97eXkUiEbW3t8vj8UiSrTLQfX19ampqUm9vr/x+v/r6+hQOh22zHaUPqgmxWGyoVyWnjKRE5ufRWG63eXUHEzf0ZGePg8ve3l6988475s8bNmzQmjVrzLGBl156qU455RRVVVVp48aN+slPfqLS0lKddNJJkqRAIKAzzjhD559/vkaNGqWSkhJdcMEFmjRpknn3+IQJE3TsscfqzDPP1J///GdJ709FNGfOHFvfKS7ZayLqj2PXvhrZBCMT29fXZ14c2CWwNGRmgDInU7dTH43tafR1x0nxrb4PZwYlsVhMHo/H3H/JeFmDEUTuOIyBbYehssfB5SuvvKKjjjrK/NkY53j66afrhhtu0GuvvaY77rhD3d3dqqqq0lFHHaX77rtPhYWF5t9cffXVcrvdOvXUUxUOh3X00Ufr9ttvHzA4/q677tK5555r3lV+/PHH69prr93rjgKDKTMgyVxmx4O90Ve7f8Wlsf3sFDgbjCAymUyaN2PZbS7ITwO7HmOGApnL7DjSdupNhlAopEAgMNSrAQCWYdev84Q1BYNBFRUVDeprGrHDL37xC/n9/kF97Ugkop///OdD0u9c47vFAQCSCCgBA5nL7Fh7MjoAAAAMKwSXAAAAyBnK4gAAABkoi2eHzCUAAAByhswlAABABjKX2SFzCQAAgJwhuAQAAEDOUBYHAADIQFk8O2QuAQAAkDNkLgEAADKQucwOmUsAAADkDJlLAACADGQus0PmEgAAADlDcAkAAICcoSwOAACQgbJ4dshcAgAAIGfIXAIAAGQgc5kdMpcAAADIGYJLAAAA5AxlcQAAgAyUxbND5hIAAAA5Q+YSAABgB3bKJA42MpcAAADIGTKXAAAAGRhzmR0ylwAAAMgZgksAAADkDGVxAACADJTFs0PmEgAAADlD5hIAACADmcvskLkEAABAzhBcAgAAIGcoiwMAAGSgLJ4dMpcAAADIGTKXAAAAGchcZofMJQAAAHKGzCUAAEAGMpfZIXMJAACAnCG4BAAAQM5QFgcAAMhAWTw7ZC4BAACQM2QuAQAAMpC5zA6ZSwAAAIu6/vrrVVdXJ7/fr/r6ej377LMf2X758uWqr6+X3+/X2LFjdeONN+7U5pprrtH48eOVl5enmpoanXfeeYpEIru9TgSXALCbHA6HnE6nnE6nHA7HUK8OgE+5++67TwsXLtTixYu1evVqzZgxQ7Nnz1ZTU9Mu22/YsEFf/vKXNWPGDK1evVo/+clPdO655+qBBx4w29x111266KKL9POf/1xr167VLbfcovvuu08XX3zxbq8XZXELyDyJ2SltDljFroLKVCplPoCh5nA4zH3T4XCYZV3OGXvHKmXxq666SmeccYa++93vSno/4/if//xHN9xwg5YsWbJT+xtvvFH77ruvrrnmGknShAkT9Morr+h3v/udTjnlFEnSypUr9YUvfEHz5s2TJI0ZM0annXaaXnrppd1eLzKXw5jD4ZDL5ZLH45HX65XH45HL5Rrq1cqacaJ2uVxyuVy2zwIZ/bVzH+3M+Bx6vV7l5+eroKBAfr9fbrfbFtvV6N+n5fNoR5nnCp/PN+B84XRymrerWCymVatWqaGhYcDyhoYGrVixYpd/s3Llyp3az5o1S6+88ori8bgk6fDDD9eqVavMYPK9997T0qVL9ZWvfGW3143M5TDldDrl8XiUl5cnv9+vdDqtSCSiSCSidDpt2WzJjoGlw+FQKpVSMplUMpm01ZW20+mU2+2Wx+OR0+lUKpVSLBZTIpGwTR/tzuFwyO12y+/3a8SIESooKJAk9ff3q6enR8lkcojXMDuZgaXb/f7pwPgs2u3zaFeZFz8+n08+n08Oh0OxWEzRaFTRaFSSLHvOGCpDmbkMhUIDlhvbdUcdHR1KJpOqqKgYsLyiokKtra27fI3W1tZdtk8kEuro6FBVVZW+/vWvq729XYcffrjS6bQSiYR+8IMf6KKLLtrtvhBcDkMOh0M+n0/FxcWqqalRSUmJgsGgNm/erEQiYV5dWJERXBpZIL/fr2Qyqb6+PoXDYSUSCaVSKcuf0JxOp3w+n0aOHKmKigr5/X51d3ervb1dPT09isfjlu+jwQhOpA8CE7twuVzy+/0qLS3Vvvvuq9LSUoVCITU3NysSiZgnbqsyApO8vDwVFhbK4/EoHA6rt7dX0WjUVhdCDofDPOaEQiFLH0czGYmI/Px8lZaWqry8XC6XS9u3b1dbW5vS6bSi0SgXChZSU1Mz4Oef//znuvTSSz+0/Y6VhnQ6/ZHVh121z1z+9NNP69e//rWuv/56TZ06Ve+8845+9KMfqaqqSj/96U93qw8El8OMw+GQx+NRcXGxDjvsMJ166qkaOXKk/vWvf6mrq0vbt28f6lXMmhFcVlZWaurUqRo1apSeffZZrVu3Tr29vbYIvNxut0aOHKkpU6bolFNOUUVFhZ566in9+9//1saNG21z0ja2Y319vSTppZdeUltbmy1O3MZJe+TIkZo4caLmzJmjUaNGafny5ero6Bjq1cuacaHndrsVCAQ0ZcoU1dfX680339SKFSvU1tZmXujZYV/Ny8vTN77xDX3xi1/UzTffrOeee87yF0LGNjT2089+9rM69thjVVRUpP/+97964YUXFI1GFY/HbXHRPpiGMnPZ3NysoqIic/muspaSVFpaKpfLtVOWsq2tbafspKGysnKX7d1ut0aNGiVJ+ulPf6r58+eb4zgnTZqkvr4+fe9739PixYt3a6gFweUw43Q6lZ+fr7Fjx+rMM8/UMccco1gspldeecW8ecDqB4h0Oi2n06mqqiqdd955GjdunP7973/rpz/9qTZu3Gj5cpxxgVBWVqYTTjhBp512mnnBsHr1am3ZssUWY9qcTqeKior0zW9+UxdeeKEcDoeuvvpq/elPf9L27dstX4YzMnpVVVWaM2eO5s+fr0gkoldffVWJRELJZNIWn0eXy6Xi4mKdfvrpmj17tt5991396Ec/UjAYVCwWs0UfpfdPxOeee64OPPBA+f1+/d///Z96enqGerWyZgzdGDFihA455BB9/etfl9/vl8Ph0Ntvv61t27Yx7tJiioqKBgSXH8br9aq+vl6NjY066aSTzOWNjY064YQTdvk306ZN0z//+c8Byx5//HFNmTJFHo9H0vvDfnbcZ1wu1x6dl9njhhmXy6X8/HyNGTNGEyZMkNPp1LZt27Ru3TqzlGPlA72xc8bjcXV3dysYDMrtdmvMmDEqKSkxxydaWWbpv6ioyPxQ9vX1KRqNWj7oMhhjcaLRqDmUo6ysTF6v1/LBszEu2O/3q7y8XJ/5zGfk9XrV2tqqjRs3mkMb7LAtje2YSCTkcDiUl5envLw8y38OdxSPx9XX1yfp/ZOynfpnHFeNMZbxeFzhcNgW+yc+2qJFi/SXv/xFt956q9auXavzzjtPTU1NWrBggSTp4osv1re+9S2z/YIFC7Rp0yYtWrRIa9eu1a233qpbbrlFF1xwgdnmuOOO0w033KB7771XGzZsUGNjo37605/q+OOP3+2bislcDiOZN7tEIhG98sor2rBhgx577DG98sorCoVCli/jGDcjRaNRbdq0SZdffrm+9KUvacOGDerq6how9sOqQXQ6nVYymVRXV5cef/xx84asRx55RM3NzbYJMNPptHp7e3XPPfdo69atKioq0rPPPquuri7L9y+z3ChJa9euVV9fn5555hm9/vrrCgaDtrnQMwby33zzzdqwYYO2bt2qDRs2mEMbrNzHTB0dHbr88st14okn6v7771d/f/9Qr1JOpFIpJRIJhUIhvfLKK/rzn/+sESNG6MUXX1RHR4etss+DySpTEc2dO1ednZ267LLL1NLSookTJ2rp0qWqra2VJLW0tAyY87Kurk5Lly7Veeedp+uuu07V1dX64x//aE5DJEmXXHKJHA6HLrnkEm3ZskVlZWU67rjj9Otf/3q318uRtukeFwqFFAgEhno19ojD4ZDX69XIkSM1evRoVVVVKRKJaNOmTdq2bZv6+/stH1xKO9/UU1hYKIfDof7+fjO7Z5Qcrcrj8aigoEClpaUqLS1VMplUW1ubOjs7FQ6HbbEdDcadxg6HwywXW/2wYmQti4uLtc8++2ifffZRIpHQpk2btGXLFoVCIfOkbWXGDT0+n08FBQUqLCw0Lxp6e3sVi8VssT0NPp9P+fn5CofDe/RtI8NZ5rG0uLhYxcXFcrlcCgaD2r59u7kdE4nEUK/qHgsGg7tVHs4lI3Y4++yzP3Ss4yclGo3q2muvHZJ+5xqZy2EmlUqpv79fmzdvVmtrq2KxmPr7+82Ayw6M7KVx4jLGdxhZFDtcZScSCfX19SkWi5k3RsTjcduUUjPZ7Q5xQyqVUiQS0bZt29Td3a1oNKqenh719fXZZjtmVhKMWRscDoeSyaRtPouZMqfmsQtjmJGRfAgGg3I4HIrH44rFYorH47b8fH7SrJK5HK4ILocRo5waiUQUi8UkyZwD0g4nskxGX41/M5db+WYeg3HAN8axScwzZyWZn0VjGyYSCTMDZKeTtRFAplIp81tejM8g++zwZ2wnI4g0xpIay+2UeYZ1EFwOMztmCux+UMg8eVl5nOWHsUOg/GlkBJfGzRHGidquX/eYuZ/a8XNod8b+alwgGMvYjhgqBJfD0Kf1gPBp7TeGHyOYzMywf1r2z09LP+3o07SfftIoi2eH4BIAdoETNQDsHYJLAACADGQus2OfWWQBAAAw5AguAQAAkDOUxQEAADJQFs8OmUsAAADkDJlLAACADGQus0PmEgAAADlD5hIAAGAHdsokDjYylwAAAMgZgksAAADkDGVxAACADNzQkx0ylwAAAMgZMpcAAAAZyFxmh8wlAAAAcobgEgAAADlDWRwAACADZfHskLkEAABAzpC5BAAAyEDmMjtkLgEAAJAzZC4BAAAykLnMDplLAAAA5AzBJQAAAHKGsjgAAEAGyuLZ2ePM5TPPPKPjjjtO1dXVcjgcevjhhwf8Pp1O69JLL1V1dbXy8vJ05JFH6o033hjQJhqN6pxzzlFpaakKCgp0/PHHa/PmzQPadHV1af78+QoEAgoEApo/f766u7v3uIMAAAAYPHscXPb19Wny5Mm69tprd/n7K664QldddZWuvfZavfzyy6qsrNQxxxyjnp4es83ChQv10EMP6d5779Vzzz2n3t5ezZkzR8lk0mwzb948rVmzRsuWLdOyZcu0Zs0azZ8/fy+6CAAAsPuMzOVgP+xij8vis2fP1uzZs3f5u3Q6rWuuuUaLFy/WySefLEn661//qoqKCt199936/ve/r2AwqFtuuUV33nmnZs6cKUn629/+ppqaGj3xxBOaNWuW1q5dq2XLlumFF17Q1KlTJUk333yzpk2bprfeekvjx4/f2/4CAADgE5TTG3o2bNig1tZWNTQ0mMt8Pp+OOOIIrVixQpK0atUqxePxAW2qq6s1ceJEs83KlSsVCATMwFKSDjvsMAUCAbPNjqLRqEKh0IAHAAAABldOg8vW1lZJUkVFxYDlFRUV5u9aW1vl9XpVXFz8kW3Ky8t3ev7y8nKzzY6WLFlijs8MBAKqqanJuj8AAODTh7J4dj6RqYgcDseAn9Pp9E7LdrRjm121/6jnufjiixUMBs1Hc3PzXqw5AAAAspHT4LKyslKSdsoutrW1mdnMyspKxWIxdXV1fWSbbdu27fT87e3tO2VFDT6fT0VFRQMeAAAAe4rMZXZyGlzW1dWpsrJSjY2N5rJYLKbly5dr+vTpkqT6+np5PJ4BbVpaWvT666+bbaZNm6ZgMKiXXnrJbPPiiy8qGAyabQAAADD87PHd4r29vXrnnXfMnzds2KA1a9aopKRE++67rxYuXKjLL79c+++/v/bff39dfvnlys/P17x58yRJgUBAZ5xxhs4//3yNGjVKJSUluuCCCzRp0iTz7vEJEybo2GOP1Zlnnqk///nPkqTvfe97mjNnDneKAwCATxSTqGdnj4PLV155RUcddZT586JFiyRJp59+um6//Xb9+Mc/Vjgc1g9/+EN1dXVp6tSpevzxx1VYWGj+zdVXXy23261TTz1V4XBYRx99tG6//Xa5XC6zzV133aVzzz3XvKv8+OOP/9C5NQEAADA8ONJ2CpUzhEIhBQKBoV4NAACwF4LB4KDfP2HEDvPnz5fX6x3U147FYrrzzjuHpN+5xneLAwAAZKAsnp1PZCoiAAAAfDqRuQQAAMhA5jI7ZC4BAACQMwSXAAAAyBnK4gAAABkoi2eHzCUAAAByhswlAABABjKX2SFzCQAAgJwhcwkMMofDYT6kD66Q7XTVajcOh+NTsX3s3k+79w+5Q+YyOwSXw5QReEj22uE+jYxA0ul0Dnik02klk0klk0m28TC040WAZN8LAWP/NPqaSqVs08/Mz5/B6FsqlRrCNQPsi+BymMg8uBv/GlfZxkHQTgd8g92DaKfTKZfLJY/HI5/PJ5/PJ6fTqWQyqWg0qkgkomQyOdSrmZXME7ddTtjG58/lcsnlcpmfSeNiIJlM2qKf0gf7qNvtltvtVjqdVjweVyKRMI85VpW5DTP7l0wmFY/Hze1o5T7uyOfzye12KxwO22YfhfUQXA4DmQd3r9drBiEej0fS+19mHw6HFY1GbXPQlyS32y2/3y+3261oNKpoNGqbg6FxUvP5fCoqKlJpaalKSkrkdrsVCoXU3t6uaDRq+UxYZuDscDjMfdQO2Vin0ym32638/HwVFhbK6/Wqr69PPT09ikQi5ufQyoz91O/3q7i4WIFAQOFwWNu3b1dfX5/i8bilt6OxDf1+v4qKihQIBORyuRQKhdTd3a3+/n7F43FbHE8lyePxaMKECSotLdVLL72kUCg01KtkWZTFs0NwOcSMrI/b7VZeXp6KiopUXl6u2tpajRs3TiNHjtSWLVv05ptvqrm5WV1dXeZB38rZE6fTqcLCQn35y1/WYYcdpn/96196/vnn1dfXZ/kPmMPhMLfn6NGjdeyxx+qII45QOBzWCy+8oJdfflmxWEyxWMzSAYrT6ZTX61VNTY3mzJkjj8ejf/3rX9q4caPC4bClt6ORufR4PCouLtaRRx6pY445Rm+88Ybuv/9+bd682eyj1fvpdrtVUlKi448/Xscee6xWrFihf/zjH4pGo0okEkO9instM/tcUFCguro6feUrX9H48eP19NNP6/HHH9fWrVttVREqKSnRJZdcovHjx+u73/2uXnrpJVv0C9ZDcDlMGAfBvLw8VVZWavr06Tr11FNVVlam7u5uPfDAA/rPf/6jt956S5LMIMyqB0Wn06nKykpddNFF+uxnP6v9999fr7/+usLhsKXLxJnbsbq6Wl/5yld04YUXatSoUVq9erUeffRRtba2KhQKKRaLWbqvTqdTfr9fs2bN0q9+9StzHOktt9xi+Sx05mcqLy9PX/7yl3XiiSeqoaFBmzdv1tKlSxWLxZRKpSy9DY3gsry8XN/5znd08MEHa8yYMXrqqafU2to6YNiKVRkXCTU1NZo3b56qq6s1btw4vf322+rq6rLF0BRDbW2tjjrqKBUVFWny5Ml65ZVXbNO3wUbmMjtMRTTEjB04mUwqFoupr69P7e3teuedd7R27VqzdON0Os1yudvtHjAOzIrS6bT6+/v17rvvqqenR01NTZbOkhiMEmNJSYn2228/TZw4UYlEQq+99ppuv/12vfLKK2pvb7fFCc04EPb29qqnp0ehUEjbt2+3dFCZKZVKKZFIKBQK6eWXX9a2bdvU1dWlVColt9ttjjO16mfQYIyx3Lp1q/r6+vTOO++ot7fX8qXizGNrNBrVtm3btG7dOoVCIbW0tCiZTA64Ycvq21F6fwiVMTSlu7vb0tsP1kbmchgwggxjAHYsFlN3d7fWrl2rqqoqpdNpdXR0qK2tTdu3b1c0GrX8mLZUKqW2tjZddNFFqqur0/r16xUMBi0dmDidTnk8HuXl5WnEiBGSpOeff17PPPOM3nvvPb377ru22X7S+yfvcDisxsZGtbe3y+FwaPXq1ba4kcAITOLxuLq6uvT3v/9dr7/+utxut9avX69IJGL5Pkoyg6+2tjZdffXVeuSRR7Ru3Tq1trZafryl9MEFQl9fn9avX68lS5ZozJgxam1t1caNGwdsR6v3VZKam5v1t7/9TaWlpXrxxRdtsY/CmhxpO3yidiEUCikQCAz1auyRzPGXxs09RobEOEgaN/QYY/WsfPAwSnKZ/bPq7mj0xefzqaCgQAUFBfJ6veaJra+vz8woWHmb7Shzf5U0YN+0gx3v9ne5XEokEorFYpYf9yx9sN96vV7l5eWZN9dFIhGz7G/Vz6TB2Ee9Xq/8fr+8Xq9SqZR5E6EdtqPB7XZr9OjRcrlc2rx5s2Kx2FCvUlaCwaCKiooG9TWN2OHUU081b6odLPF4XH//+9+HpN+5RuZyGDGyCKlUSvF4XJFI5EMn27bqWMtMRmbIDjLnBwyHw2ZGJJFIDJi6xurbbEfGvmoMabDDfpnJ2GZGPzO3sx22Z2bZ2NiGRt/s0D/pg+ylURUyhjNk9tMOgaX0/sXdli1bzP8DQ4Xgchiy2wn608IIQIxyohGU2H1b2n1/zbzo2/FCzw4yA2jJXn0zGH00xlka7NhXgsrc4Iae7BBcAjlgBB52Gr+FgewYiBjs3DeD0T+79xMYDggugRzhpAUA9kDmMjtMRQQAAGBR119/verq6uT3+1VfX69nn332I9svX75c9fX18vv9Gjt2rG688cad2nR3d+uss85SVVWV/H6/JkyYoKVLl+72OhFcAgAAWNB9992nhQsXavHixVq9erVmzJih2bNnq6mpaZftN2zYoC9/+cuaMWOGVq9erZ/85Cc699xz9cADD5htYrGYjjnmGG3cuFH333+/3nrrLd18880aPXr0bq8XUxEBAIBhZyinIjrllFOGZCqiBx54YI/6PXXqVB1yyCG64YYbzGUTJkzQiSeeqCVLluzU/sILL9Sjjz6qtWvXmssWLFigV199VStXrpQk3Xjjjbryyiu1bt26vX4PyFwCAAAME6FQaMAjGo3usl0sFtOqVavU0NAwYHlDQ4NWrFixy79ZuXLlTu1nzZqlV155xZwa8NFHH9W0adN01llnqaKiQhMnTtTll1++R98qR3AJAACQYVfzSg/GQ5JqamoUCATMx64ykJLU0dGhZDKpioqKAcsrKirU2tq6y79pbW3dZftEIqGOjg5J0nvvvaf7779fyWRSS5cu1SWXXKLf//73+vWvf73b7x93iwMAAAwTzc3NA8riPp/vI9tnzt0qvR8Y77js49pnLk+lUiovL9dNN90kl8ul+vp6bd26VVdeeaV+9rOf7VYfCC4BAACGiaKiot0ac1laWiqXy7VTlrKtrW2n7KShsrJyl+3dbrdGjRolSaqqqpLH45HL5TLbTJgwQa2trYrFYvJ6vR+7bpTFAQAAMgxlWXx3eb1e1dfXq7GxccDyxsZGTZ8+fZd/M23atJ3aP/7445oyZYp5884XvvAFvfPOOwO+FvXtt99WVVXVbgWWEsElAACAJS1atEh/+ctfdOutt2rt2rU677zz1NTUpAULFkiSLr74Yn3rW98y2y9YsECbNm3SokWLtHbtWt1666265ZZbdMEFF5htfvCDH6izs1M/+tGP9Pbbb+uxxx7T5ZdfrrPOOmu314uyOAAAQAarfEPP3Llz1dnZqcsuu0wtLS2aOHGili5dqtraWklSS0vLgDkv6+rqtHTpUp133nm67rrrVF1drT/+8Y865ZRTzDY1NTV6/PHHdd555+mggw7S6NGj9aMf/UgXXnjhbq8X81wCAIBhZyjnuTzxxBOHZJ7Lhx9+eEj6nWtkLgEAADJYJXM5XDHmEgAAADlDcAkAAICcoSwOAACQgbJ4dshcAgAAIGfIXAIAAGQgc5kdMpcAAADIGYJLAAAA5AxlcQAAgAyUxbND5hIAAAA5Q+YSAAAgA5nL7JC5BAAAQM4QXAIAACBnKIsDAABkoCyeHTKXAAAAyBkylwAAABnIXGaHzCUAAAByhswlAABABjKX2SFzCQAAgJwhuAQAAEDOUBYHAADIQFk8O2QuAQAAkDNkLgEAADKQucwOmUsAAADkDMElAAAAcoayOAAAQAbK4tkhcwkAAICcIXMJAACQgcxldshcAgAAIGfIXAIAAOzATpnEwUbmEgAAADlD5nKYczgc5v+5igIAAMMdweUw5XA45HQ6zeAynU4rlUoRYAIA8Anjhp7sEFwOQ0Zg6Xa75XK5JEnJZFKJRELJZHKI1w4fx+FwDHgYB6mhOFgNBuMCaMcsux37CgD4eASXw5DT6ZTH45Hf75fX61U6nVY0GjVP2KlUaqhXER/B4XDI5XLJ7XbL6Xx/WHMqlTIvDuwSeBkXQcZjxyy78bBDXwEryLyolcT5IgtkLrNDcDnMGCdsn8+nQCCgkSNHKh6Pq6ury3aZy8ygxC6BiLH9PB6P8vLylJeXJ5fLpXg8rv7+fkUiEcXjccv31QigPR6PvF6vfD6fXC6X0um0YrGY+ZBk+b5KMvvqcDiUSCSUSCQs36ddMfZfSbY61kgDL4ZSqZTt+mdUu4yL2nQ6be6rdvgMwloILocZh8Mht9utgoICjRkzRuPHj1d3d7def/11hcNhWwQmkuTxeFRYWKiysjL5/X51dnZq+/btikQilr/SNoLLoqIi1dTUqKqqSuFwWO+9955aWlrU19enWCxm2W1o7KNer1cjRoxQaWmpqqqq5Pf7FQwG1d7eru3bt9sm0+7xeFRcXKy6ujo5nU5t2rRJHR0dZvBsBw6HQz6fT6NGjVJJSYna2trU0dFhmwDM6F9VVZXKysq0ZcsWtbW1KR6PD/Wq5YRxzDE+j4WFhQqFQtq+fbt6e3sVj8dtsy1hDQSXw4xx4h45cqRmzpypefPm6X//+5/++Mc/qq2tbcC4NqtyuVwaMWKEDj30UJ177rnad9999d///lc33XST3nvvPUUiEcsGXgan06n8/HwddNBB+s53viO/368777xTjz76qLZs2WLZ8njmeOCCggJVV1drxowZ+trXviafz6elS5dq+fLlCofDikQiA8adWpHT6dSIESP0la98Reeee67C4bCWLFmi5cuXKx6PW7ZfO/L5fJo1a5bOP/98RaNRXXDBBero6Bjq1coZp9Op6upq/epXv9Jhhx2mW2+9Vddff726urosvw2NKkJ+fr72228/nXnmmZo4caIee+wxPfjgg4rFYkokEkO9mpZDWTw7BJfDjHHyLigo0NSpU1VXVye3262ioiKzXGV1RhbhoIMO0lFHHSWfz6eysjI9//zz2rJlizm+1KrS6bSSyaSSyaR5wC8sLNTs2bP18ssvq7OzU9Fo1AwwrSSzHF5QUKDRo0dr5syZmj59ulKplNatW6fnn3/eNjcxOZ1OlZSU6Gtf+5omT56seDyu8ePH67nnnhvqVcsZh8OhkpISnX/++Tr88MP19ttvKxwOW3q77cjpdGrMmDGaNWuWiouLdeSRR+q2225Td3e35ftpnDPy8vI0efJkfe1rX1NhYaGSyaQaGxvN84aVL/JgPfaIVmwoHo9r/fr1am9v1//+9z91dXVZMhjZlVQqpf7+fq1atUrPPfecWlpa9OKLL2rr1q2WL90YZeB4PK5gMKg1a9aosbFRGzZs0IYNG8zgLPMGGKvJHLuWTCb13nvv6c0339Tzzz+v559/Xtu2bVN/f79txnql02l1dHQoEolow4YNevPNN21XEi8sLJTL5dLmzZt12223qaWlxfLbLVM6nda2bdu0atUqbdmyRY2Njerr67NNH41x6+3t7Vq3bp22bt2q5557Tl1dXWaG3S59HSw7XiAP1sMuHGk79SZDKBRSIBAY6tXYYy6XS3l5eSovL9dBBx2k8ePHa8OGDVqzZo1aWloUDodtUeJwu90aMWKEqqurVVpaqu3bt2vLli3m+CArM4Y2+Hw+lZSUqLa2VqNHj1ZfX582bdqk1tZW9fT0KBaLWS6YNkriPp/PHN9VUVGhoqIi9fT0aMuWLero6FBvb6/ZPysfYpxOpwKBgCZNmqSDDz5Y7777rl5++WVt377dFp9D6f0+VlRU6IADDlAwGNQ777yj3t5ey4+VzeRwOFRQUKC6ujoFAgG988476ujosMU2NI43eXl5Ki0tVW1trfx+vzZu3KiWlhb19/dbdghHMBhUUVHRoL6mETsceeSRcrsHt7ibSCT09NNPD0m/c43gcphxOp3yer0qKipSWVmZCgoK1Nvbq/b2djMgsctB3+l0mlk84+5Nu/XN6/UqPz9feXl5cjgcikaj6u/vVzQaNW/OspLMaZa8Xq/5cDgcisfjikajikajA6ZdsrrMacGi0agikYgtghKDEZwYd8LbLYNiyOynMWzFLoyLPo/HI4/HI+n96lc8HjcrCFY0lMHlEUccMSTB5fLly20RXDLmcpgxxuuFw2G1t7erq6tLsVjMzFja6aBvTD9kR0Y52JgOpK+vb0AQbdXAy9g/jX9jsZhZ3je2p1VvVvowxgk6c0J8O0mn05avFuwOO/czcx7daDQqiW91w9AiuBxmjAOCkaE0xtLYZQqiTxMjADMO/Hb5tp7MfmVmf4z+WLVfH8XK2wufDna9UIc1EVwOQ0YwYhwsMr/xBNZi56DEzn0D8OnGVETZIbgchjKDSbuW4gAAgD0RXA5Tdi4xAgAwnJG5zA7zXAIAACBnch5cXnrppeZXvhmPyspK8/fpdFqXXnqpqqurlZeXpyOPPFJvvPHGgOeIRqM655xzVFpaqoKCAh1//PHavHlzrlcVAAAAOfaJZC4/+9nPqqWlxXy89tpr5u+uuOIKXXXVVbr22mv18ssvq7KyUsccc4x6enrMNgsXLtRDDz2ke++9V88995x6e3s1Z84cW81LBgAAhie+oSc7n8iYS7fbPSBbaUin07rmmmu0ePFinXzyyZKkv/71r6qoqNDdd9+t73//+woGg7rlllt05513aubMmZKkv/3tb6qpqdETTzyhWbNmfRKrDAAAgBz4RDKX69evV3V1terq6vT1r39d7733niRpw4YNam1tVUNDg9nW5/PpiCOO0IoVKyRJq1atUjweH9CmurpaEydONNsAAAB8UshcZifnmcupU6fqjjvu0Gc+8xlt27ZNv/rVrzR9+nS98cYbam1tlSRVVFQM+JuKigpt2rRJktTa2iqv16vi4uKd2hh/vyvG184ZQqFQrroEAACA3ZTz4HL27Nnm/ydNmqRp06Zp3Lhx+utf/6rDDjtMksyvizOk0+mdlu3o49osWbJEv/jFL7JYcwAAAKYiytYnPhVRQUGBJk2apPXr15vjMHfMQLa1tZnZzMrKSsViMXV1dX1om125+OKLFQwGzUdzc3OOewIAAICP84kHl9FoVGvXrlVVVZXq6upUWVmpxsZG8/exWEzLly/X9OnTJUn19fXyeDwD2rS0tOj111832+yKz+dTUVHRgAcAAAAGV87L4hdccIGOO+447bvvvmpra9OvfvUrhUIhnX766XI4HFq4cKEuv/xy7b///tp///11+eWXKz8/X/PmzZMkBQIBnXHGGTr//PM1atQolZSU6IILLtCkSZPMu8cBAAA+KZTFs5Pz4HLz5s067bTT1NHRobKyMh122GF64YUXVFtbK0n68Y9/rHA4rB/+8Ifq6urS1KlT9fjjj6uwsNB8jquvvlput1unnnqqwuGwjj76aN1+++1yuVy5Xl0AAADkkCNtp1A5QygUUiAQGOrVAAAAeyEYDA76EDcjdjjssMPkdn8iU4F/qEQioRdeeGFI+p1rfLc4AAAAcobgEgAAwKKuv/561dXVye/3q76+Xs8+++xHtl++fLnq6+vl9/s1duxY3XjjjR/a9t5775XD4dCJJ564R+tEcAkAAJDBKt/Qc99992nhwoVavHixVq9erRkzZmj27NlqamraZfsNGzboy1/+smbMmKHVq1frJz/5ic4991w98MADO7XdtGmTLrjgAs2YMWOP14sxlwAAYNgZyjGXU6dOHZIxly+++OIe9Xvq1Kk65JBDdMMNN5jLJkyYoBNPPFFLlizZqf2FF16oRx99VGvXrjWXLViwQK+++qpWrlxpLksmkzriiCP0ne98R88++6y6u7v18MMP73ZfyFwCAABksELmMhaLadWqVWpoaBiwvKGhQStWrNjl36xcuXKn9rNmzdIrr7yieDxuLrvssstUVlamM844Y4/WyTC4YTkAAAA+VCgUGvCzz+eTz+fbqV1HR4eSyeRO315YUVGx0zchGlpbW3fZPpFIqKOjQ1VVVXr++ed1yy23aM2aNXvdBzKXAAAAGYYyc1lTU6NAIGA+dlXezuRwOHZa9x2XfVx7Y3lPT4+++c1v6uabb1ZpaenevHWSyFwCAAAMG83NzQPGXO4qaylJpaWlcrlcO2Up29radspOGiorK3fZ3u12a9SoUXrjjTe0ceNGHXfccebvU6mUJMntduutt97SuHHjPrYPBJcAAADDRFFR0W7d0OP1elVfX6/GxkaddNJJ5vLGxkadcMIJu/ybadOm6Z///OeAZY8//rimTJkij8ejAw44QK+99tqA319yySXq6enRH/7wB9XU1OxWHwguAQAAMljlu8UXLVqk+fPna8qUKZo2bZpuuukmNTU1acGCBZKkiy++WFu2bNEdd9wh6f07w6+99lotWrRIZ555plauXKlbbrlF99xzjyTJ7/dr4sSJA15j5MiRkrTT8o9CcAkAAGBBc+fOVWdnpy677DK1tLRo4sSJWrp0qWprayVJLS0tA+a8rKur09KlS3XeeefpuuuuU3V1tf74xz/qlFNOyel6Mc8lAAAYdoZynsv6+vohmedy1apVfLc4AAAAkIngEgAAADnDmEsAAIAd2HTU4KAgcwkAAICcIXMJAACQwSpTEQ1XZC4BAACQM2QuAQAAMpC5zA6ZSwAAAOQMwSUAAAByhrI4AABABsri2SFzCQAAgJwhcwkAAJCBzGV2yFwCAAAgZwguAQAAkDOUxQEAADJQFs8OmUsAAADkDJlLAACADGQus0PmEgAAADlD5hIAIIfDYf7fThkUAIOP4HKYcjgc5sHeONDb8YDvcDjkdH6QQE+n00qlUkO4RrmVuR2loSm1AB/F2Ed3tZ/aZV/dsX+SvT+LO547sOcoi2eH4HKYMYItp9M54ABhBF12OSAa/XS5XHK73XI6nUqlUkokEkokEpYPMI2TWea2NLahnbajtPOFkF36ZTC24459tENfjX65XK5d7qfGw8oyjzXGhWwqlVIymTQ/i3awq3OH0T879RPWQHA5jBgHBrfbLY/HI4/HI6fTqWQyqVgspng8bosDonEQ9Hq9ys/PV0FBgZxOp8LhsPr6+ix/4s48mXk8Hnm93l1uR6v2z2Dsr5knbWP/tEP/JA24AHK73XI4HEomk0okEkomk5bup3FRYBxvfD6f3G63ksmkotGoYrGYJOtfMBjHVJ/PJ7/fL4fDoWg0qkgkong8bvnjqfTBfur1euX3++V2u5VKpRSLxWx1zBlMZC6zQ3A5TGQe6PPy8hQIBFRWVqZAIKBgMKjW1lYFg0FFIhHLH+wdDoc8Ho8CgYDGjBmjcePGKRwO65133tHWrVsVj8fNDIoVZQbPgUBAVVVVKiwsVHt7u7Zt26be3l5LB9CZgbPf79fIkSNVWlqqVCqljo4Ocz+1+gnN6Kff79eoUaNUU1Mjh8Oh1tZWbd++XX19fZJk2T4a+6nH41FhYaFGjx6t6upqbd++XU1NTeru7lYkEjEzl1buo9frVUlJifbbbz+VlJRo/fr1ampqUm9vr+LxuCX7ZjCC5/z8fJWVlamurk7FxcXq6OjQ5s2b1dHRob6+PlsE0bAOgsthxDhI5OXlqaamRqeeeqqOPvpovfrqq7r55pu1bt26AZlLKx4ojBKc3+9XTU2NzjjjDM2aNUv/+9//dN1116m9vX2nsVFWY5zQ/H6/xowZo3PPPVeTJk3Sgw8+qLvuukvRaFSJRMKSAbQRjPj9fhUXF2vs2LGaPXu2vvzlLyuZTOqRRx5RY2OjNm7caAYnVhzmYFzseTwejRo1SieddJJ+8IMfKBaL6brrrlNjY6Oi0aji8fhQr+peyRy24fF4VFZWpm9+85s65ZRTtHr1av3ud7/T2rVrLX+BkLkd99lnH1144YWaPHmy/vGPf+hPf/qTotGo2T8r9jHzWFNWVqYjjjhCP/jBD1RZWaknnnhCd911l/r6+hSJRCx/XB1sZC6zQ3A5DDmdThUWFuoLX/iCDjjgAJWVlemJJ57Qpk2b1Nvbax4wrbgjGgfDvLw81dbWqqGhQfvss4/C4bBZyrHqgT6TcaEwevRoHXXUUSotLdURRxyhRx99VC6Xy5IH+swxXV6vV0VFRaqrq9PRRx+tCRMmKJ1OKxQK6e2331ZnZ6f6+/vN4MSKnE6nfD6fysrK9KUvfUn77befYrGYysvLbTV21ul0Kj8/X4cccohGjx4tl8ul0tJSud3vnx6suK8aMrdNfn6+9t9/f5WWlurzn/+8ioqKLPtZNBgX60ZmdsqUKTrooIPkcrlUV1cnl8tlu5skYQ0El8OIMVYtGo2qtbVVy5Ytk8vl0ttvv62WlhYlEgnLn8ikD8bqxWIxrV+/Xg6HQ48//riam5sViUQsG4xkMm5O2rJli5544glNmjRJTzzxhEKhkGUzQel0WslkUg6HQ+FwWG1tbVq1apWuvfZaHXXUUUomk/rvf/+rV199VR0dHQqHw5bMWkoDb1Lq6+vT448/Lq/Xq+bmZj3xxBMKBoOWL6cagXEikVBXV5ceeeQRSdKrr76qzZs3m/2zch+l9z+L8Xhczc3Nuuuuu3TkkUeqsbFRPT09tuifIRqN6o033tBzzz0nl8ul+++/X01NTerr6zMrXsBgcaTt8snaQSgUUiAQGOrV2COZg7JHjBihsrIylZaWKhKJqL29Xd3d3QOyQVbcdEYZrqioSKNHj9a4cePk9Xr1zjvvaNOmTQqFQorFYpY+EBrb0efzKRAIqLKyUgUFBero6FBbW5v6+vosvQ0zb1gybiDIz89XOp1WOBxWOBxWPB43L4as2kdjXGleXp4KCwuVn5+vaDQ64HNo5XFsmVno/Px8lZSUaOTIkQqHw+rs7FRPT485hMOq21H64JhTUFCg0tJSFRcXq6enRx0dHerp6TGPN1bsnzFO3+/3q7CwUKNGjVJxcbESiYS2bdum7du3D9hXrSYYDKqoqGhQX9OIHSZMmCCXyzWor51MJrV27doh6XeukbkcRowPfywWUygUUiQSUUtLi5ldME7YVj0QSh/MYxkOh9XS0qKuri6lUin19fWZQYkVD4KZjD7GYjEzEHE6nUokEorFYrbYhkYmJJFIKBKJKBgMmr+zQ7nY6KPxr7ENjZ/tMGuDsa3i8bh5wdPR0aF0Oq14PD7gAsjq/UwkEmYf29vbzX5bPXA29kej4tPX16fNmzeb/cucYQQYTASXw0zmvGTGTR/SwJO2lQ8UxsHQyBYYd04bU7tYuW+GzG1kHOR3NX+g1WXOv2rHSZszg2g7ToRv9CEziM6cH9EOFwnSwCA6mUyaFwmZn0cryzwv7Dh9lB2231Dhhp7sEFwOQ7s6qRk7nR12PiNwzhxbafUs0I52DDAzl9upnwY79slg120mDQwwjeNN5rHGLv3ODLQyjzt26p8dxqrDPgguhzE7Hdx3ZPVswe6w0wUB7CtzP7XqLBS7y859A4YTgksAgCSCL8BAWTw7zqFeAQAAANgHmUsAAIAMZC6zQ+YSAAAAOUPmEgAAIAOZy+yQuQQAAEDOEFwCAAAgZyiLAwAAZKAsnh0ylwAAAMgZMpcAAAAZyFxmh8wlAAAAcobgEgAAADlDWRwAACADZfHskLkEAABAzpC5BAAA2IGdMomDjcwlAAAAcobMJQAAQAbGXGaHzCUAAAByhuASAAAAOUNZHAAAIANl8eyQuQQAAEDOkLkEAADIQOYyO2QuAQAAkDMElwAAAMgZyuIAAAAZKItnh8wlAAAAcobMJQAAQAYyl9khcwkAAICcIXMJAACQgcxldshcAgAAIGcILgEAACzq+uuvV11dnfx+v+rr6/Xss89+ZPvly5ervr5efr9fY8eO1Y033jjg9zfffLNmzJih4uJiFRcXa+bMmXrppZf2aJ0ILgEAADIYZfHBfuyp++67TwsXLtTixYu1evVqzZgxQ7Nnz1ZTU9Mu22/YsEFf/vKXNWPGDK1evVo/+clPdO655+qBBx4w2zz99NM67bTT9NRTT2nlypXad9991dDQoC1btuz2ejnSdiryZwiFQgoEAkO9GgAAYC8Eg0EVFRUN6msascPo0aPldA5u/i2VSmnLli171O+pU6fqkEMO0Q033GAumzBhgk488UQtWbJkp/YXXnihHn30Ua1du9ZctmDBAr366qtauXLlLl8jmUyquLhY1157rb71rW/t1nqRuQQAAMhghcxlLBbTqlWr1NDQMGB5Q0ODVqxYscu/Wbly5U7tZ82apVdeeUXxeHyXf9Pf3694PK6SkpLdXjfuFgcAABgmQqHQgJ99Pp98Pt9O7To6OpRMJlVRUTFgeUVFhVpbW3f53K2trbtsn0gk1NHRoaqqqp3+5qKLLtLo0aM1c+bM3e4DmUsAAIBhoqamRoFAwHzsqrydyeFwDPg5nU7vtOzj2u9quSRdccUVuueee/Tggw/K7/fvbhfIXAIAAGQaynkum5ubB4y53FXWUpJKS0vlcrl2ylK2tbXtlJ00VFZW7rK92+3WqFGjBiz/3e9+p8svv1xPPPGEDjrooD3qC5lLAACAYaKoqGjA48OCS6/Xq/r6ejU2Ng5Y3tjYqOnTp+/yb6ZNm7ZT+8cff1xTpkyRx+Mxl1155ZX65S9/qWXLlmnKlCl73IdhH1zu6fxNAAAA2bDCDT2StGjRIv3lL3/RrbfeqrVr1+q8885TU1OTFixYIEm6+OKLB9zhvWDBAm3atEmLFi3S2rVrdeutt+qWW27RBRdcYLa54oordMkll+jWW2/VmDFj1NraqtbWVvX29u72eg3r4HJP528CAAD4tJg7d66uueYaXXbZZTr44IP1zDPPaOnSpaqtrZUktbS0DIiZ6urqtHTpUj399NM6+OCD9ctf/lJ//OMfdcopp5htrr/+esViMX31q19VVVWV+fjd73632+s1rOe53NP5mzIxzyUAANY1lPNcVlRUDMk8l9u2bRuSfufasM1c7s38TQAAABhaw/Zu8T2dvykajSoajZo/B4PBT3wdAQDAJ2MYF1bxMYZt5tKwu/M3LVmyZMC8UPvuu+9grSIAAMixnp6eIXttq9zQM1wN28zlns7fdPHFF2vRokXmz93d3aqtrVVTUxNjLwdJKBRSTU3NTnN04ZPB+z24eL8HF+/34Bsu73k6nVZPT4+qq6uHbB2QnWEbXGbO33TSSSeZyxsbG3XCCSfs1P7Dvh4pEAhwYBpkxtxcGBy834OL93tw8X4PvuHwng91UmgoJ1G3g2EbXErvz980f/58TZkyRdOmTdNNN900YP4mAAAADC/DOricO3euOjs7ddlll6mlpUUTJ04cMH8TAAAAhpdhHVxK0g9/+EP98Ic/3OO/8/l8+vnPf/6hX5uE3OM9H1y834OL93tw8X4PPt7zD1AWz86wnkQdAABgsBiTqJeWlg7JJOodHR22mER92GcuAQAABhOZy+wM+3kuAQAAYB1kLgEAADKQucwOmUsAAADkjG2Dy+uvv151dXXy+/2qr6/Xs88+O9SrZDmXXnqpHA7HgEdlZaX5+3Q6rUsvvVTV1dXKy8vTkUceqTfeeGPAc0SjUZ1zzjkqLS1VQUGBjj/+eG3evHmwuzJsPfPMMzruuONUXV0th8Ohhx9+eMDvc/Ued3V1af78+ebXo86fP1/d3d2fcO+Gn497v7/97W/vtM8fdthhA9rwfu++JUuW6POf/7wKCwtVXl6uE088UW+99daANuzjubM77zf7OAaDLYPL++67TwsXLtTixYu1evVqzZgxQ7Nnz1ZTU9NQr5rlfPazn1VLS4v5eO2118zfXXHFFbrqqqt07bXX6uWXX1ZlZaWOOeaYAd8Hu3DhQj300EO699579dxzz6m3t1dz5sxRMpkciu4MO319fZo8ebKuvfbaXf4+V+/xvHnztGbNGi1btkzLli3TmjVrNH/+/E+8f8PNx73fknTssccO2OeXLl064Pe837tv+fLlOuuss/TCCy+osbFRiURCDQ0N6uvrM9uwj+fO7rzfEvv47uC7xbOUtqFDDz00vWDBggHLDjjggPRFF100RGtkTT//+c/TkydP3uXvUqlUurKyMv2b3/zGXBaJRNKBQCB94403ptPpdLq7uzvt8XjS9957r9lmy5YtaafTmV62bNknuu5WJCn90EMPmT/n6j1+880305LSL7zwgtlm5cqVaUnpdevWfcK9Gr52fL/T6XT69NNPT59wwgkf+je839lpa2tLS0ovX748nU6zj3/Sdny/02n28Y8TDAbTktLFxcXpUaNGDeqjuLg4LSkdDAaH+m3Imu0yl7FYTKtWrVJDQ8OA5Q0NDVqxYsUQrZV1rV+/XtXV1aqrq9PXv/51vffee5KkDRs2qLW1dcD77PP5dMQRR5jv86pVqxSPxwe0qa6u1sSJE9kWuyFX7/HKlSsVCAQ0depUs81hhx2mQCDAdtiFp59+WuXl5frMZz6jM888U21tbebveL+zEwwGJUklJSWS2Mc/aTu+3wb28d2TJmu512wXXHZ0dCiZTKqiomLA8oqKCrW2tg7RWlnT1KlTdccdd+g///mPbr75ZrW2tmr69Onq7Ow038uPep9bW1vl9XpVXFz8oW3w4XL1Hre2tqq8vHyn5y8vL2c77GD27Nm666679OSTT+r3v/+9Xn75ZX3pS19SNBqVxPudjXQ6rUWLFunwww/XxIkTJbGPf5J29X5L7OMYHLadisjhcAz4OZ1O77QMH2327Nnm/ydNmqRp06Zp3Lhx+utf/2oOAN+b95ltsWdy8R7vqj3bYWdz5841/z9x4kRNmTJFtbW1euyxx3TyySd/6N/xfn+8s88+W//73//03HPP7fQ79vHc+7D3m30cg8F2mcvS0lK5XK6drp7a2tp2ujrGnikoKNCkSZO0fv16867xj3qfKysrFYvF1NXV9aFt8OFy9R5XVlZq27ZtOz1/e3s72+FjVFVVqba2VuvXr5fE+723zjnnHD366KN66qmntM8++5jL2cc/GR/2fu8K+/iuDXZJ3G6lcdsFl16vV/X19WpsbBywvLGxUdOnTx+itbKHaDSqtWvXqqqqSnV1daqsrBzwPsdiMS1fvtx8n+vr6+XxeAa0aWlp0euvv8622A25eo+nTZumYDCol156yWzz4osvKhgMsh0+Rmdnp5qbm1VVVSWJ93tPpdNpnX322XrwwQf15JNPqq6ubsDv2cdz6+Pe711hH8cnYi9vBBrW7r333rTH40nfcsst6TfffDO9cOHCdEFBQXrjxo1DvWqWcv7556effvrp9HvvvZd+4YUX0nPmzEkXFhaa7+NvfvObdCAQSD/44IPp1157LX3aaaelq6qq0qFQyHyOBQsWpPfZZ5/0E088kf6///u/9Je+9KX05MmT04lEYqi6Naz09PSkV69enV69enVaUvqqq65Kr169Or1p06Z0Op279/jYY49NH3TQQemVK1emV65cmZ40aVJ6zpw5g97fofZR73dPT0/6/PPPT69YsSK9YcOG9FNPPZWeNm1aevTo0bzfe+kHP/hBOhAIpJ9++ul0S0uL+ejv7zfbsI/nzse93+zjH8+4WzwQCKRHjhw5qI9AIGCbu8VtGVym0+n0ddddl66trU17vd70IYccMmAqBuyeuXPnpquqqtIejyddXV2dPvnkk9NvvPGG+ftUKpX++c9/nq6srEz7fL70F7/4xfRrr7024DnC4XD67LPPTpeUlKTz8vLSc+bMSTc1NQ12V4atp556Ki1pp8fpp5+eTqdz9x53dnamv/GNb6QLCwvThYWF6W984xvprq6uQerl8PFR73d/f3+6oaEhXVZWlvZ4POl99903ffrpp+/0XvJ+775dvdeS0rfddpvZhn08dz7u/WYf/3gEl7nhSKdtVOQHAADYS6FQyPzWocG+OSmdTisYDCoYDKqoqGhQXzvXbHu3OAAAwN4YirybnXJ9truhBwAAAEOHzCUAAEAGMpfZIXMJAACAnCFzCQAAkIHMZXbIXAIAACBnCC4BAACQM5TFAQAAMlAWzw6ZSwAAAOQMmUsAAIAMZC6zQ+YSAAAAOUNwCQAAgJyhLA4AAJCBsnh2yFwCAAAgZ8hcAgAAZCBzmR0ylwAAAMgZMpcAAAAZyFxmh8wlAAAAcobgEgAAADlDWRwAACADZfHskLkEAABAzpC5BAAAyEDmMjtkLgEAAJAzBJcAAADIGcriAAAAGSiLZ4fMJQAAAHKGzCUAAEAGMpfZIXMJAACAnCFzCQAAkIHMZXbIXAIAACBnCC4BAACQM5TFAQAAMlAWzw6ZSwAAAOQMmUsAAIAMZC6zQ+YSAAAAOUNwCQAAgJyhLA4AALADO5WpBxuZSwAAAOQMwSUAAIAkr9erysrKIXv9yspKeb3eIXv9XHGkyfsCAABIkiKRiGKx2JC8ttfrld/vH5LXziWCSwAAAOQMZXEAAADkDMElAAAAcobgEgAAADlDcAkAAICcIbgEAABAzhBcAgAAIGcILgEAAJAz/z+YNZ4jUoJq8wAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 800x800 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "img = simu_dict[\"Y106\"][0][\"sci\"][f\"shear_{g1_in}_{g2_in}\"]\n",
+    "m = np.mean(img)\n",
+    "s = np.std(img)\n",
+    "plt.figure(figsize=(8, 8))\n",
+    "plt.imshow(img, origin=\"lower\", cmap=\"grey\", vmin=max(m-3*s, np.min(m)), vmax=m+10*s)\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c5a6564",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "roman_sim",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/achromatic_galaxy_catalog.ipynb
+++ b/notebooks/achromatic_galaxy_catalog.ipynb
@@ -34,6 +34,7 @@
     "seed = 4242\n",
     "rng = np.random.RandomState(seed)\n",
     "\n",
+    "simu_type = \"sca\"\n",
     "simu_size = 301\n",
     "img_size = 251\n",
     "bands = [\"Y106\", \"J129\", \"H158\"]\n",
@@ -75,6 +76,7 @@
     "galaxy_catalog = GalaxyCatalog(\n",
     "    simu_size,\n",
     "    seed,\n",
+    "    simu_type=simu_type,\n",
     "    flux_range=flux_range,\n",
     "    layout_kind=layout_kind,\n",
     "    exp_time=exp_time,\n",
@@ -95,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "4688b969",
    "metadata": {},
    "outputs": [],
@@ -123,7 +125,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6a031c3216144b0a8aa0fd020eb297d7",
+       "model_id": "c0c4b1550b8d4257ab6e668ba0e0589a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -137,7 +139,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8d0760571d9f46ffa069d73286af6bf8",
+       "model_id": "cc4cddf27195488591e0aaf9be8904c0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -151,7 +153,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dc81f977e8844905bfa4bece553213a8",
+       "model_id": "126e67a342794c0faac5502a8d46e2ca",
        "version_major": 2,
        "version_minor": 0
       },
@@ -165,7 +167,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cc56801ccd714454b52361620f79c603",
+       "model_id": "583e80f02cb6496880a54eef9f66c995",
        "version_major": 2,
        "version_minor": 0
       },
@@ -179,7 +181,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2d2eb1edd3dc4571989154b93cce5c48",
+       "model_id": "9b53f8ac3a504e60b7c58bd2827d8729",
        "version_major": 2,
        "version_minor": 0
       },
@@ -193,7 +195,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f7639716910b41f4b90f49fac5641fd9",
+       "model_id": "e1d67718ac1e4a0bb3901595dc7639c6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -207,7 +209,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bf6637542ff6429aa894e3382bdcadbf",
+       "model_id": "afbde145527149b38c4e51c22a449385",
        "version_major": 2,
        "version_minor": 0
       },
@@ -224,6 +226,7 @@
     "    rng,\n",
     "    galaxy_catalog,\n",
     "    psf_maker,\n",
+    "    simu_type=simu_type,\n",
     "    n_epochs=n_epochs,\n",
     "    exp_time=exp_time,\n",
     "    cell_size_pix=simu_size,\n",
@@ -256,7 +259,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.colorbar.Colorbar at 0x315dec320>"
+       "<matplotlib.colorbar.Colorbar at 0x3356a6960>"
       ]
      },
      "execution_count": 7,

--- a/notebooks/achromatic_simple_catalog.ipynb
+++ b/notebooks/achromatic_simple_catalog.ipynb
@@ -34,6 +34,7 @@
     "seed = 4242\n",
     "rng = np.random.RandomState(seed)\n",
     "\n",
+    "simu_type = \"sca\"\n",
     "simu_size = 301\n",
     "img_size = 251\n",
     "bands = [\"Y106\", \"J129\", \"H158\"]\n",
@@ -75,6 +76,7 @@
     "galaxy_catalog = SimpleGalaxyCatalog(\n",
     "    simu_size,\n",
     "    seed,\n",
+    "    simu_type=simu_type,\n",
     "    gal_type=gal_type,\n",
     "    mag=gal_mag,\n",
     "    hlr=gal_hlr,\n",
@@ -97,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "4688b969",
    "metadata": {},
    "outputs": [],
@@ -125,7 +127,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "734487647ded4647a8fa27313c86f675",
+       "model_id": "2b37960321534b28b29b1831a51467f3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -139,7 +141,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1f4dedb99ce643459ad4a89615989e27",
+       "model_id": "bf862c3bcd2f4fc2bd7506b60e734a52",
        "version_major": 2,
        "version_minor": 0
       },
@@ -153,7 +155,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fb756374a2d4423aa5cd5652b974fc28",
+       "model_id": "20db2f767d5f4439bdec337fec191fbe",
        "version_major": 2,
        "version_minor": 0
       },
@@ -167,7 +169,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "66feba01ecb04363906de8d4e2506ed7",
+       "model_id": "2e680951b0304dd78b54ee50c58439ba",
        "version_major": 2,
        "version_minor": 0
       },
@@ -181,7 +183,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9962bb6587454565a8f5e3cd84aa6b46",
+       "model_id": "fc511fd05ce2410c86b7a7b4164d95aa",
        "version_major": 2,
        "version_minor": 0
       },
@@ -195,7 +197,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b4394714a43e4347a730de628bb9c6b0",
+       "model_id": "0e4dcd83201f4fd7af278ce88bd765fb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -209,7 +211,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e40c8b613b9242ed9ced42489372e1aa",
+       "model_id": "601ec6cea058470ea8a09176aa29d27a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -226,6 +228,7 @@
     "    rng,\n",
     "    galaxy_catalog,\n",
     "    psf_maker,\n",
+    "    simu_type=simu_type,\n",
     "    n_epochs=n_epochs,\n",
     "    exp_time=exp_time,\n",
     "    cell_size_pix=simu_size,\n",
@@ -258,7 +261,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.colorbar.Colorbar at 0x3334dfe90>"
+       "<matplotlib.colorbar.Colorbar at 0x32d42c380>"
       ]
      },
      "execution_count": 7,

--- a/src/roman_shear_sims/constant.py
+++ b/src/roman_shear_sims/constant.py
@@ -15,3 +15,14 @@ WORLD_ORIGIN = galsim.CelestialCoord(
     ra=10.161290322580646 * galsim.degrees,
     dec=-43.40685848593699 * galsim.degrees,
 )
+
+# IMCOM constants
+IMCOM_BLOCK_SIZE = 2688
+IMCOM_PIXEL_SCALE = 0.0390625
+IMCOM_PSF_FWHM = {
+    "Y106": 0.22,
+    "J129": 0.231,
+    "H158": 0.242,
+    "F184": 0.253,
+    "K213": 0.264,
+}


### PR DESCRIPTION
Make modification to allow the simulation of IMCOM coadds. It is very simple and only include IMCOM WCS and PSF. Simulate IMCOM blocks. It does not include the correct IMCOM noise or flux unit.